### PR TITLE
[Fix] 모바일 스크롤 문제 해결 및 헤더/네비게이션바 고정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.1",
+        "tailwind-scrollbar": "^3.1.0",
+        "tailwind-scrollbar-hide": "^2.0.0",
         "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
@@ -5092,6 +5094,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-scrollbar": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-3.1.0.tgz",
+      "integrity": "sha512-pmrtDIZeHyu2idTejfV59SbaJyvp1VRjYxAjZBH0jnyrPRo6HL1kD5Glz8VPagasqr6oAx6M05+Tuw429Z8jxg==",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "3.x"
+      }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-2.0.0.tgz",
+      "integrity": "sha512-lqiIutHliEiODwBRHy4G2+Tcayo2U7+3+4frBmoMETD72qtah+XhOk5XcPzC1nJvXhXUdfl2ajlMhUc2qC6CIg==",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.1",
+    "tailwind-scrollbar": "^3.1.0",
+    "tailwind-scrollbar-hide": "^2.0.0",
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -11,8 +11,7 @@ body {
   max-width: 500px;
   width: 100%;
   margin: 0 auto;
-  min-height: 100vh;
-  height: 100%;
+  min-height: calc(var(--vh, 1vh) * 100);
   box-shadow: rgb(100, 100, 100, 0.2) 0px 0px 29px 0px;
   padding: 0px;
 }
@@ -51,4 +50,16 @@ body {
 
 .read-the-docs {
   color: #888;
+}
+
+@supports (-webkit-touch-callout: none) {
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  #root {
+    height: calc(var(--vh, 1vh) * 100);
+  }
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,16 +1,39 @@
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import NavBar from './NavBar';
+import { useEffect, useRef, useState } from 'react';
 
 // 로그인 이후 사용 가능한 페이지 -> 헤더와 해당 페이지가 렌더링 되는 것으로 레이아웃이 동일함
 const Layout = () => {
+  const headerHeight = useRef<HTMLDivElement>(null);
+  const navBarHeight = useRef<HTMLDivElement>(null);
+  const [heights, setHeights] = useState({ header: 0, navbar: 0 });
+
+  useEffect(() => {
+    if (headerHeight.current && navBarHeight.current) {
+      const header = headerHeight.current.offsetHeight;
+      const navBar = navBarHeight.current.offsetHeight;
+      setHeights({ header: header, navbar: navBar });
+    }
+  }, []);
+
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <main className="flex-grow px-4">
+    <div className="flex flex-col min-h-screen scrollbar-none">
+      <div className="fixed w-full max-w-[500px]" ref={headerHeight}>
+        <Header />
+      </div>
+      <main
+        className="flex-grow px-4 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300"
+        style={{
+          marginTop: `${heights.header}px`,
+          marginBottom: `${heights.navbar}px`,
+          // 이거 100vh로 안하고 이걸로 햇는데... 딱히 적용이 안되는 것 같아서 나중에 확인해봐야함.
+          height: `calc(calc(var(--vh, 1vh) * 100) - ${heights.header + heights.navbar}px)`,
+        }}
+      >
         <Outlet />
       </main>
-      <footer className="sticky bottom-0 h-1/8">
+      <footer className="fixed bottom-0 max-w-[500px] w-full h-1/8" ref={navBarHeight}>
         <NavBar />
       </footer>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,5 +82,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar')],
 };


### PR DESCRIPTION
## 🔥 Issues


## ✅ What to do

- [x] 모바일에서 스크롤 바를 Outlet 내부에만 표시하도록 수정  
- [x] 헤더와 네비게이션 바를 고정하고, 남는 공간을 동적으로 계산하여 Outlet에 적용

## 📄 Description
* 헤더와 네비게이션 바를 상하단에 `fixed`로 고정하여 화면에 항상 표시되도록 구현.
* 고정된 헤더와 네비게이션 바의 높이를 동적으로 계산한 후, 나머지 영역에 콘텐츠를 표시하도록 설정.

## 🤔 Considerations
* 전체 화면에 스크롤이 생기는 문제를 해결하기 위해, (전체 화면 높이 - (헤더 높이 + 네비게이션 바 높이)) 값을 <Outlet/>에 적용해야겠다고 생각했다.
* 헤더와 네비게이션 바의 높이가 고정값이 아니고 내부 요소에 따라 동적될 수 있기 때문에, useRef를 사용해 두 요소의 높이를 동적으로 가져오도록 구현했다.
* useEffect를 활용해 화면 렌더링 시 헤더와 네비게이션 바의 높이를 가져오고, 이 값을 활용해 Outlet의 높이를 다음과 같이 설정함
```height: `calc(calc(var(--vh, 1vh) * 100) - ${heights.header + heights.navbar}px)```

## 🛠️ Improvements to Make
* 현재 100vh 대신 calc(var(--vh, 1vh) * 100)를 사용했지만, 이 값이 정확히 반영되고 있는지 잘 모르겠다... 추후 점검이 필요함...


## 👀 References
* https://s0ojin.tistory.com/56
* https://woodduru-madduru.tistory.com/4

| ![Image 1](https://github.com/user-attachments/assets/7b65da48-8fb0-4227-9413-a5ce15518e16) | ![Image 2](https://github.com/user-attachments/assets/197dbf2d-369e-474a-9b36-1ae42af61c05) | ![Image 3](https://github.com/user-attachments/assets/192f8c33-1c42-48e4-8551-ffd7f95a7b64) |
|---|---|---|
| **Safari 앱** | **Google 앱** | **Chrome(노트북)** |
