### PR TITLE
[Feat] accessToken, refreshToken 처리 기능 구현

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -13,9 +13,9 @@ instance.interceptors.request.use(
   (config) => {
     // 요청이 전달되기 전에 헤더에 토큰 추가
     // 추후에 바꿔도 될 듯 => 상의 필요
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    const accesstoken = localStorage.getItem('accesstoken');
+    if (accesstoken) {
+      config.headers.Authorization = `Bearer ${accesstoken}`;
     }
     return config;
   },
@@ -28,7 +28,34 @@ instance.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
+  async (error) => {
+    // 토큰 만료 시
+    const msg = error.response.data.msg; // 백엔드에서 토큰 만료됐다고 알려주는 msg("Expired Access Token")
+    if (error.response.status === 401 && msg === 'Expired Access Token') {
+      try {
+        const res = await axios.post(
+          '/백에서 주는 url',
+          {},
+          {
+            headers: {
+              accessToken: `${localStorage.getItem('accessToken')}`,
+              refreshToken: `${localStorage.getItem('refreshToken')}`,
+            },
+          },
+        );
+        localStorage.setItem('accessToken', res.headers.accessToken);
+        localStorage.setItem('refreshToken', res.headers.refreshToken);
+
+        error.config.headers.Authorization = `Bearer ${res.headers.accessToken}`;
+        return axios(error.config);
+      } catch (refreshErr) {
+        console.log(refreshErr);
+
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+      }
+    }
     return Promise.reject(error);
   },
 );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -11,11 +11,10 @@ const instance: AxiosInstance = axios.create({
 
 instance.interceptors.request.use(
   (config) => {
-    // 요청이 전달되기 전에 헤더에 토큰 추가
-    // 추후에 바꿔도 될 듯 => 상의 필요
-    const accesstoken = localStorage.getItem('accesstoken');
-    if (accesstoken) {
-      config.headers.Authorization = `Bearer ${accesstoken}`;
+    // 요청이 전달되기 전 헤더에 토큰 추가
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
   },
@@ -31,25 +30,26 @@ instance.interceptors.response.use(
   async (error) => {
     // 토큰 만료 시
     const msg = error.response.data.msg; // 백엔드에서 토큰 만료됐다고 알려주는 msg("Expired Access Token")
+    const refreshToken = localStorage.getItem('refreshToken');
     if (error.response.status === 401 && msg === 'Expired Access Token') {
       try {
-        const res = await axios.post(
-          '/백에서 주는 url',
-          {},
-          {
-            headers: {
-              accessToken: `${localStorage.getItem('accessToken')}`,
-              refreshToken: `${localStorage.getItem('refreshToken')}`,
+        if (refreshToken) {
+          const res = await axios.post(
+            '/백에서 주는 url',
+            { refreshToken },
+            {
+              headers: {
+                'Content-Type': 'application/json',
+              },
             },
-          },
-        );
-        localStorage.setItem('accessToken', res.headers.accessToken);
-        localStorage.setItem('refreshToken', res.headers.refreshToken);
+          );
+          localStorage.setItem('accessToken', res.headers.accessToken);
 
-        error.config.headers.Authorization = `Bearer ${res.headers.accessToken}`;
-        return axios(error.config);
+          error.config.headers.Authorization = `Bearer ${res.headers.accessToken}`;
+          return axios(error.config);
+        }
       } catch (refreshErr) {
-        console.log(refreshErr);
+        console.log('Token 갱신 실패: ', refreshErr);
 
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');

--- a/src/components/KakaoLoginButton.tsx
+++ b/src/components/KakaoLoginButton.tsx
@@ -1,12 +1,12 @@
-import Kakao_logo from '../assets/images/Kakao_logo.png';
+import kakao_logo from '../assets/images/kakao_logo.png';
 
 const KakaoLoginButton = () => {
   const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API;
   const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
+  const KAKAO_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
 
   const handleKakaoLogin = () => {
-    window.location.href = kakaoURL;
+    window.location.href = KAKAO_URL;
   };
 
   return (
@@ -16,7 +16,7 @@ const KakaoLoginButton = () => {
         onClick={handleKakaoLogin}
       >
         <div className="flex justify-center items-center gap-2 px-6">
-          <img className="w-4 h-4" alt="카카오 로그인" src={Kakao_logo} />
+          <img className="w-4 h-4" alt="카카오 로그인" src={kakao_logo} />
           <h3>카카오로 계속하기</h3>
         </div>
       </button>

--- a/src/components/KakaoOauth.tsx
+++ b/src/components/KakaoOauth.tsx
@@ -11,9 +11,14 @@ const KakaoOauth = () => {
   const handleAuth = async () => {
     if (!code) return;
 
-    const { accessToken, status } = await postAuthCode(code);
-    console.log(accessToken);
-    console.log(status);
+    const { accessToken, refreshToken, status } = await postAuthCode(code);
+
+    if (accessToken) {
+      localStorage.setItem('accesstoken', accessToken);
+    }
+    if (refreshToken) {
+      localStorage.setItem('refreshToken', refreshToken);
+    }
 
     if (status === 'existing') {
       // 이미 회원인 경우 로그인 완료 -> 메인페이지로 이동

--- a/src/utils/RoleList.ts
+++ b/src/utils/RoleList.ts
@@ -1,6 +1,6 @@
-import Boy from '../assets/images/Boy.png';
-import Mom from '../assets/images/Mom.png';
-import Teacher from '../assets/images/Teacher.png';
+import boy from '../assets/images/boy.png';
+import mom from '../assets/images/mom.png';
+import teacher from '../assets/images/teacher.png';
 
 export interface Role {
   id: number;
@@ -15,21 +15,21 @@ export const RoleList: Role[] = [
     id: 0,
     title: '학생',
     description: '선생님과 소통하고 과제를 제출해요.',
-    src: Boy,
+    src: boy,
     role: 'student',
   },
   {
     id: 1,
     title: '선생님',
     description: '학생, 학부모와 소통하고 수업해요.',
-    src: Teacher,
+    src: teacher,
     role: 'teacher',
   },
   {
     id: 2,
     title: '학부모',
     description: '선생님과 소통하고 입금해요.',
-    src: Mom,
+    src: mom,
     role: 'parent',
   },
 ];


### PR DESCRIPTION
## 🔥 Issues
#9 

## ✅ What to do

- [x] accessToken, refreshToken 처리 기능 구현

## 📄 Description
- 작동 원리
1. 사용자가 로그인하면 서버는 클라이언트에게 accessToken과 refreshToken을 동시에 발급한다.
2. 서버는 데이터베이스에 refreshToken을 저장하고, 클라이언트는 accessToken과 refreshToken을 웹스토리지에 저장하고 요청이 있을 때마다 accessToken을 헤더에 담아서 보낸다.
3. 만약 accessToken이 만료되었으면 백에서 만료되었다는 메시지를 전송한다.
4. refreshToken이 있을 경우 post 하면 백에서 기존에 가지고 있던 것과 같으면 새로운 accessToken을 응답으로 보낸다.
5. 새로운 accessToken으로 localstorage에 저장하고 로그인. 
6. 만약 refreshToken이 만료되었다면 로그아웃 처리 후 로그인 창으로 이동.

## 🤔 Considerations
전체적인 흐름과 어떻게 갱신할 지 고민을 했다.

## 🛠️ Improvements to Make
instance.interceptors.request.use에서 헤더에 accessToken과 refreshToken 둘 다 보내는 경우도 있어서 고려해봐야 할 듯.
refreshToken은 보안상의 이유로 보통 쿠키에 저장한다고 해서 이 부분도 고민해봐야 할 듯.

## 👀 References
https://velog.io/@wynter24/React%EC%99%80-Axios%EB%A1%9C-%EA%B5%AC%ED%98%84%ED%95%98%EB%8A%94-%ED%9A%A8%EC%9C%A8%EC%A0%81%EC%9D%B8-%EC%9D%B8%EC%A6%9D-%EC%8B%9C%EC%8A%A4%ED%85%9C-%EC%95%A1%EC%84%B8%EC%8A%A4-%EB%A6%AC%ED%94%84%EB%A0%88%EC%8B%9C-%ED%86%A0%ED%81%B0-%EC%9E%90%EB%8F%99-%EA%B0%B1%EC%8B%A0