### PR TITLE
[Feat] 과외방 수정 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,6 +3494,45 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.22.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "core-js-compat": "^3.38.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",

--- a/src/components/PermissionToggle.tsx
+++ b/src/components/PermissionToggle.tsx
@@ -1,28 +1,29 @@
-import { Permission } from '../context/RoomContext';
+import { Permission } from '../utils/PermissionList';
 
 type TypeProps = {
-  type: Permission;
-  handleCheck: (id: number) => void;
+  permission: Permission;
+  isChecked: boolean;
+  handleToggleCheck: (id: number, permission: string) => void;
 };
 
-const PermissionToggle = ({ type, handleCheck }: TypeProps) => {
+const PermissionToggle = ({ permission, handleToggleCheck, isChecked }: TypeProps) => {
   return (
     <div className="flex">
-      {type.title}
+      {permission.title}
       <input
-        id={`permission-${type.id}`}
+        id={`permission-${permission.id}`}
         type="checkbox"
-        checked={type.isChecked}
+        checked={isChecked}
         className="hidden"
-        onChange={() => handleCheck(type.id)}
+        onChange={() => handleToggleCheck(permission.id, permission.type)}
       />
       <label
-        htmlFor={`permission-${type.id}`}
-        className={`relative block w-10 h-6 bg-gray-100 rounded-lg cursor-pointer transition ${type.isChecked ? 'bg-green-400' : 'bg-gray-200'}
+        htmlFor={`permission-${permission.id}`}
+        className={`relative block w-10 h-6 bg-gray-100 rounded-lg cursor-pointer transition ${isChecked ? 'bg-green-400' : 'bg-gray-200'}
           before:content-[''] 
           before:absolute before:top-0.5 before:left-0.5 
           before:w-5 before:h-5 before:bg-white before:rounded-full before:transition 
-          ${type.isChecked ? 'before:translate-x-4' : ''}`}
+          ${isChecked ? 'before:translate-x-4' : ''}`}
       />
     </div>
   );

--- a/src/components/RoomEditor.tsx
+++ b/src/components/RoomEditor.tsx
@@ -1,0 +1,136 @@
+import PermissionToggle from '../components/PermissionToggle';
+import SelectDate from '../components/SelectDate';
+import { useEffect, useState } from 'react';
+import { OnSubmit, Room } from '../context/RoomContext';
+import { WeekList } from '../utils/WeekList';
+import { ParentPermissions, StudentPermissions } from '../utils/PermissionList';
+
+type EditProps = {
+  currentRoom: Room | undefined;
+  onSubmit: OnSubmit;
+};
+
+const RoomEditor = ({ currentRoom, onSubmit }: EditProps) => {
+  useEffect(() => {
+    if (currentRoom) {
+      setInput(currentRoom);
+    }
+  }, [currentRoom]);
+
+  const [input, setInput] = useState({
+    roomName: '',
+    studentName: '',
+    subject: '',
+    days: [''],
+    parentPermissions: ['counseling', 'payment'],
+    studentPermissions: ['materials', 'homework', 'stats'],
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.placeholder === '방이름') setInput((prev) => ({ ...prev, roomName: e.target.value }));
+    if (e.target.placeholder === '학생이름') setInput((prev) => ({ ...prev, studentName: e.target.value }));
+    if (e.target.placeholder === '과목명') setInput((prev) => ({ ...prev, subject: e.target.value }));
+  };
+
+  const handleToggleCheck = (id: number, permission: string) => {
+    if (id >= 3 && id <= 7) return;
+    else if (id < 5)
+      setInput((prev) => {
+        const newPermissions = prev.parentPermissions.includes(permission)
+          ? prev.parentPermissions.filter((p) => p !== permission)
+          : [...prev.parentPermissions, permission];
+        return {
+          ...prev,
+          parentPermissions: newPermissions.sort(
+            (a, b) =>
+              ParentPermissions.find((permission) => permission.type === a)?.id! -
+              ParentPermissions.find((permission) => permission.type === b)?.id!,
+          ),
+        };
+      });
+    else if (id >= 5)
+      setInput((prev) => {
+        const newPermissions = prev.studentPermissions.includes(permission)
+          ? prev.studentPermissions.filter((p) => p !== permission)
+          : [...prev.studentPermissions, permission];
+        return {
+          ...prev,
+          studentPermissions: newPermissions.sort(
+            (a, b) =>
+              StudentPermissions.find((permission) => permission.type === a)?.id! -
+              StudentPermissions.find((permission) => permission.type === b)?.id!,
+          ),
+        };
+      });
+  };
+
+  const handleWeekClick = (day: string) => {
+    setInput((prev) => {
+      const newDays = prev.days.includes(day) ? prev.days.filter((d) => d !== day) : [...prev.days, day];
+      const sortedDays = newDays.sort(
+        (a, b) => WeekList.find((week) => week.date === a)?.id! - WeekList.find((week) => week.date === b)?.id!,
+      );
+
+      return { ...prev, days: sortedDays };
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-16">
+      <input placeholder="방이름" onChange={handleInputChange} value={input.roomName} />
+      <input placeholder="학생이름" onChange={handleInputChange} value={input.studentName} />
+      <input placeholder="과목명" onChange={handleInputChange} value={input.subject} />
+      <div className="flex gap-4 justify-center">
+        {WeekList.map((week) => (
+          <SelectDate
+            key={week.id}
+            week={week}
+            isClicked={input.days.includes(week.date)}
+            handleWeekClick={handleWeekClick}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between">
+        <div className="flex flex-col">
+          <h1>학부모 권한설정</h1>
+          {ParentPermissions.map((permission) => (
+            <PermissionToggle
+              key={permission.id}
+              isChecked={input.parentPermissions.includes(permission.type)}
+              permission={permission}
+              handleToggleCheck={handleToggleCheck}
+            />
+          ))}
+        </div>
+        <div className="flex flex-col">
+          <h1>학생 권한설정</h1>
+          {StudentPermissions.map((permission) => (
+            <PermissionToggle
+              key={permission.id}
+              isChecked={input.studentPermissions.includes(permission.type)}
+              permission={permission}
+              handleToggleCheck={handleToggleCheck}
+            />
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={() =>
+          onSubmit(
+            0,
+            input.roomName,
+            input.studentName,
+            input.subject,
+            input.days,
+            input.parentPermissions,
+            input.studentPermissions,
+          )
+        }
+        className="text-white"
+      >
+        완료
+      </button>
+    </div>
+  );
+};
+export default RoomEditor;

--- a/src/components/RoomInfo.tsx
+++ b/src/components/RoomInfo.tsx
@@ -1,12 +1,14 @@
 import { MdDeleteOutline } from 'react-icons/md';
 import { CiEdit } from 'react-icons/ci';
 import { Room, useRoomContext } from '../context/RoomContext';
+import { useNavigate } from 'react-router-dom';
 
 type RoomProps = {
   room: Room;
 };
 
 const RoomInfo = ({ room }: RoomProps) => {
+  const navigate = useNavigate();
   const { onDelete } = useRoomContext();
 
   const handleDelete = (id: number) => {
@@ -19,10 +21,12 @@ const RoomInfo = ({ room }: RoomProps) => {
         <img className="w-9 h-9" />
       </div>
       <div className="flex flex-1 flex-col text-gray-900 cursor-pointer">
-        <h1 className="text-body1 font-bold leading-9">{room.roomName}</h1>
-        <h3 className="text-body4 font-regular leading-6">학생이름</h3>
+        <h1 className="text-body1 font-bold leading-9">
+          [{room.subject}] {room.roomName}
+        </h1>
+        <h3 className="text-body4 font-regular leading-6">{room.studentName}</h3>
       </div>
-      <div className="cursor-pointer">
+      <div className="cursor-pointer" onClick={() => navigate(`${room.id}/edit`)}>
         <CiEdit size={20} />
       </div>
       <div className="cursor-pointer" onClick={() => handleDelete(room.id)}>

--- a/src/components/SelectDate.tsx
+++ b/src/components/SelectDate.tsx
@@ -1,18 +1,19 @@
-import { Day } from '../context/RoomContext';
+import { Week } from '../utils/WeekList';
 
-type DayProps = {
-  day: Day;
-  handleClick: (id: number) => void;
+type WeekProps = {
+  week: Week;
+  isClicked: boolean;
+  handleWeekClick: (day: string) => void;
 };
 
-const SelectDate = ({ day, handleClick }: DayProps) => {
+const SelectDate = ({ week, isClicked, handleWeekClick }: WeekProps) => {
   return (
     <div>
       <button
-        className={`px-4 text-white  ${day.isClicked ? 'bg-black' : 'bg-gray-300'}`}
-        onClick={() => handleClick(day.id)}
+        className={`px-4 text-white  ${isClicked ? 'bg-black' : 'bg-gray-300'}`}
+        onClick={() => handleWeekClick(week.date)}
       >
-        {day.date}
+        {week.date}
       </button>
     </div>
   );

--- a/src/context/RoomContext.tsx
+++ b/src/context/RoomContext.tsx
@@ -1,47 +1,29 @@
 import { createContext, ReactNode, useContext, useState, useRef } from 'react';
 
-export type Day = {
-  id: number;
-  date: string;
-  isClicked: boolean;
-};
-
-export type Permission = {
-  id: number;
-  type: string;
-  title: string;
-  isChecked: boolean;
-};
-
 export type Room = {
   id: number;
   roomName: string;
+  studentName: string;
   subject: string;
   days: string[];
-  pMaterials: boolean;
-  pHomework: boolean;
-  pStats: boolean;
-  pCounseling: true;
-  pPayment: true;
-  sMaterials: true;
-  sHomework: true;
-  sStats: true;
-  sCounseling: boolean;
-  sPayment: boolean;
+  parentPermissions: string[];
+  studentPermissions: string[];
 };
+
+export type OnSubmit = (
+  id: number,
+  roomName: string,
+  studentName: string,
+  subject: string,
+  days: string[],
+  parentPermissions: string[],
+  studentPermissions: string[],
+) => void;
 
 type RoomContextType = {
   rooms: Room[];
-  onCreate: (
-    roomName: string,
-    subject: string,
-    days: string[],
-    pMaterials: boolean,
-    pHomework: boolean,
-    pStats: boolean,
-    sCounseling: boolean,
-    sPayment: boolean,
-  ) => void;
+  onCreate: OnSubmit;
+  onUpdate: OnSubmit;
   onDelete: (id: number) => void;
 };
 
@@ -60,37 +42,50 @@ export const RoomProvider = ({ children }: { children: ReactNode }) => {
   const idRef = useRef(0);
 
   const onCreate = (
+    id: number,
     roomName: string,
+    studentName: string,
     subject: string,
     days: string[],
-    pMaterials: boolean,
-    pHomework: boolean,
-    pStats: boolean,
-    sCounseling: boolean,
-    sPayment: boolean,
+    parentPermissions: string[],
+    studentPermissions: string[],
   ) => {
     const newRoom: Room = {
       id: idRef.current++,
       roomName: roomName,
+      studentName: studentName,
       subject: subject,
       days: days,
-      pMaterials: pMaterials,
-      pHomework: pHomework,
-      pStats: pStats,
-      pCounseling: true,
-      pPayment: true,
-      sMaterials: true,
-      sHomework: true,
-      sStats: true,
-      sCounseling: sCounseling,
-      sPayment: sPayment,
+      parentPermissions: parentPermissions,
+      studentPermissions: studentPermissions,
     };
     setRooms([...rooms, newRoom]);
+  };
+
+  const onUpdate = (
+    id: number,
+    roomName: string,
+    studentName: string,
+    subject: string,
+    days: string[],
+    parentPermissions: string[],
+    studentPermissions: string[],
+  ) => {
+    const updatedRoom: Room = {
+      id: id,
+      roomName: roomName,
+      studentName: studentName,
+      subject: subject,
+      days: days,
+      parentPermissions: parentPermissions,
+      studentPermissions: studentPermissions,
+    };
+    setRooms(rooms.map((room) => (room.id === id ? updatedRoom : room)));
   };
 
   const onDelete = (id: number) => {
     setRooms(rooms.filter((room) => room.id !== id));
   };
 
-  return <RoomContext.Provider value={{ rooms, onCreate, onDelete }}>{children}</RoomContext.Provider>;
+  return <RoomContext.Provider value={{ rooms, onCreate, onUpdate, onDelete }}>{children}</RoomContext.Provider>;
 };

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -1,127 +1,29 @@
-import PermissionToggle from '../components/PermissionToggle';
-import SelectDate from '../components/SelectDate';
-import { useEffect, useState } from 'react';
-import { useRoomContext } from '../context/RoomContext';
-import { Day, Permission } from '../context/RoomContext';
+import RoomEditor from '../components/RoomEditor';
+import { useState } from 'react';
+import { Room, useRoomContext } from '../context/RoomContext';
 import { useNavigate } from 'react-router-dom';
 
 const CreateRoom = () => {
   const navigate = useNavigate();
-  const { onCreate, rooms } = useRoomContext();
-  const [roomName, setRoomName] = useState('');
-  const [subject, setSubject] = useState('');
-  const [dayList, setDayList] = useState<Day[]>([
-    { id: 0, date: '월', isClicked: false },
-    { id: 1, date: '화', isClicked: false },
-    { id: 2, date: '수', isClicked: false },
-    { id: 3, date: '목', isClicked: false },
-    { id: 4, date: '금', isClicked: false },
-    { id: 5, date: '토', isClicked: false },
-    { id: 6, date: '일', isClicked: false },
-  ]);
-  const [days, setDays] = useState<string[]>([]);
-
-  const [parentP, setparentP] = useState<Permission[]>([
-    { id: 0, type: 'materials', title: '강의 자료함', isChecked: false },
-    { id: 1, type: 'homework', title: '주차별 숙제', isChecked: false },
-    { id: 2, type: 'stats', title: '성적 통계', isChecked: false },
-    { id: 3, type: 'counseling', title: '상담 일지', isChecked: true },
-    { id: 4, type: 'payment', title: '입금', isChecked: true },
-  ]);
-  const [studentP, setstudentP] = useState<Permission[]>([
-    { id: 5, type: 'materials', title: '강의 자료함', isChecked: true },
-    { id: 6, type: 'homework', title: '주차별 숙제', isChecked: true },
-    { id: 7, type: 'stats', title: '성적 통계', isChecked: true },
-    { id: 8, type: 'counseling', title: '상담 일지', isChecked: false },
-    { id: 9, type: 'payment', title: '입금', isChecked: false },
-  ]);
-
-  const handleClick = (id: number) => {
-    setDayList(dayList.map((day) => (id === day.id ? { ...day, isClicked: !day.isClicked } : day)));
-  };
-
-  useEffect(() => {
-    const selectedDays = dayList.filter((day) => day.isClicked).map((day) => day.date);
-    setDays(selectedDays);
-  }, [dayList]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.placeholder === '방이름') setRoomName(e.target.value);
-    if (e.target.placeholder === '과목명') setSubject(e.target.value);
-  };
-
-  const handleCheck = (id: number) => {
-    if (id >= 3 && id <= 7) return;
-    else if (id < 5)
-      setparentP(parentP.map((type) => (id === type.id ? { ...type, isChecked: !type.isChecked } : type)));
-    else if (id >= 5)
-      setstudentP(studentP.map((type) => (id === type.id ? { ...type, isChecked: !type.isChecked } : type)));
-  };
-  console.log(rooms);
+  const [currentRoom, setCurrentRoom] = useState<Room | undefined>(undefined);
+  const { onCreate } = useRoomContext();
 
   const handleCreate = (
+    id: number,
     roomName: string,
+    studentName: string,
     subject: string,
     days: string[],
-    pMaterials: boolean,
-    pHomework: boolean,
-    pStats: boolean,
-    sCounseling: boolean,
-    sPayment: boolean,
+    parentPermissions: string[],
+    studentPermissions: string[],
   ) => {
-    onCreate(
-      roomName,
-      subject,
-      days,
-      parentP[0].isChecked,
-      parentP[1].isChecked,
-      parentP[2].isChecked,
-      studentP[3].isChecked,
-      studentP[4].isChecked,
-    );
+    onCreate(id, roomName, studentName, subject, days, parentPermissions, studentPermissions);
     navigate('/user/roomlist');
   };
-  return (
-    <div className="flex flex-col gap-16">
-      <input placeholder="방이름" onChange={handleChange} value={roomName} />
-      <input placeholder="과목명" onChange={handleChange} value={subject} />
-      <div className="flex gap-4 justify-center">
-        {dayList.map((day) => (
-          <SelectDate key={day.id} day={day} handleClick={handleClick} />
-        ))}
-      </div>
-      <div className="flex justify-between">
-        <div className="flex flex-col">
-          <h1>학부모 권한설정</h1>
-          {parentP.map((type) => (
-            <PermissionToggle key={type.id} type={type} handleCheck={handleCheck} />
-          ))}
-        </div>
-        <div className="flex flex-col">
-          <h1>학생 권한설정</h1>
-          {studentP.map((type) => (
-            <PermissionToggle key={type.id} type={type} handleCheck={handleCheck} />
-          ))}
-        </div>
-      </div>
 
-      <button
-        onClick={() =>
-          handleCreate(
-            roomName,
-            subject,
-            days,
-            parentP[0].isChecked,
-            parentP[1].isChecked,
-            parentP[2].isChecked,
-            studentP[3].isChecked,
-            studentP[4].isChecked,
-          )
-        }
-        className="text-white"
-      >
-        완료
-      </button>
+  return (
+    <div>
+      <RoomEditor currentRoom={currentRoom} onSubmit={handleCreate} />
     </div>
   );
 };

--- a/src/pages/EditRoom.tsx
+++ b/src/pages/EditRoom.tsx
@@ -1,0 +1,40 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { Room, useRoomContext } from '../context/RoomContext';
+import { useEffect, useState } from 'react';
+import RoomEditor from '../components/RoomEditor';
+
+const EditRoom = () => {
+  const navigate = useNavigate();
+  const params = useParams<{ roomId: string }>();
+  const paramsId = Number(params.roomId);
+  const { rooms, onUpdate } = useRoomContext();
+  const [currentRoom, setCurrentRoom] = useState<Room | undefined>(undefined);
+
+  useEffect(() => {
+    const currentRoom = rooms.find((room) => room.id === paramsId);
+    if (!currentRoom) {
+      window.alert('존재하지 않는 과외방입니다.');
+      navigate('roomlist');
+    } else {
+      setCurrentRoom(currentRoom);
+    }
+  }, [params.roomId, rooms, navigate]);
+  console.log(currentRoom);
+
+  const handleUpdate = (
+    id: number,
+    roomName: string,
+    studentName: string,
+    subject: string,
+    days: string[],
+    parentPermissions: string[],
+    studentPermissions: string[],
+  ) => {
+    onUpdate(paramsId, roomName, studentName, subject, days, parentPermissions, studentPermissions);
+    navigate('/user/roomlist');
+  };
+
+  return <RoomEditor currentRoom={currentRoom} onSubmit={handleUpdate} />;
+};
+
+export default EditRoom;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -16,6 +16,7 @@ import Payment from '../pages/Payment';
 import Statistics from '../pages/Statistics';
 import CreateRoom from '../pages/CreateRoom';
 import KakaoOauth from '../components/KakaoOauth';
+import EditRoom from '../pages/EditRoom';
 
 export const router = createBrowserRouter([
   {
@@ -48,6 +49,7 @@ export const router = createBrowserRouter([
             path: ':roomId',
             children: [
               { index: true, element: <RoomDetail /> },
+              { path: 'edit', element: <EditRoom /> },
               { path: 'materials', element: <Materials /> },
               { path: 'homework', element: <Homework /> },
               { path: 'stats', element: <Statistics /> },

--- a/src/utils/PermissionList.ts
+++ b/src/utils/PermissionList.ts
@@ -1,0 +1,21 @@
+export interface Permission {
+  id: number;
+  type: string;
+  title: string;
+}
+
+export const ParentPermissions: Permission[] = [
+  { id: 0, type: 'materials', title: '강의 자료함' },
+  { id: 1, type: 'homework', title: '주차별 숙제' },
+  { id: 2, type: 'stats', title: '성적 통계' },
+  { id: 3, type: 'counseling', title: '상담 일지' }, //true
+  { id: 4, type: 'payment', title: '입금' }, //true
+];
+
+export const StudentPermissions: Permission[] = [
+  { id: 5, type: 'materials', title: '강의 자료함' }, //true
+  { id: 6, type: 'homework', title: '주차별 숙제' }, //true
+  { id: 7, type: 'stats', title: '성적 통계' }, //true
+  { id: 8, type: 'counseling', title: '상담 일지' },
+  { id: 9, type: 'payment', title: '입금' },
+];

--- a/src/utils/WeekList.ts
+++ b/src/utils/WeekList.ts
@@ -1,0 +1,14 @@
+export interface Week {
+  id: number;
+  date: string;
+}
+
+export const WeekList: Week[] = [
+  { id: 0, date: '월' },
+  { id: 1, date: '화' },
+  { id: 2, date: '수' },
+  { id: 3, date: '목' },
+  { id: 4, date: '금' },
+  { id: 5, date: '토' },
+  { id: 6, date: '일' },
+];


### PR DESCRIPTION
## 🔥 Issues

#19 

## ✅ What to do

- [x] 과외방 생성 기능 수정
- [x] 과외방 수정 기능 구현
- [ ] 방 생성 및 수정 시 백에 정보 넘겨주기

## 📄 Description
기존의 생성 코드를 따로 Editor로 빼고 CreateRoom, EditRoom 페이지의 컴포넌트로 각각 넣었다.

## 🤔 Considerations

방 수정 시 기존 정보를 불러와야 할 것 -> 방 id를 params로 가져와서 일치하는 정보를 currentRoom으로 가져옴

## 🛠️ Improvements to Make

아직 백에 넘겨주는 부분의 코드는 안 짬. 추후 추가해야 한다.
API 명세서 보니까 다른 부분이 좀 있어서 이 부분 수정해야 할 듯.

## 👀 References

스크린샷 또는 참고사항
