### PR TITLE
[Feat] 과외방 상세 조회 동작 구현

### DIFF
--- a/src/components/DetailButton.tsx
+++ b/src/components/DetailButton.tsx
@@ -3,9 +3,11 @@ import 강의자료함 from '/강의자료함.png';
 
 interface DetailButtonProps {
   type: string;
+  nextDepositDate?: string;
+  isPermission: boolean;
 }
 
-const DetailButton = ({ type }: DetailButtonProps) => {
+const DetailButton = ({ type, nextDepositDate, isPermission }: DetailButtonProps) => {
   let title = '';
   let description = '';
 
@@ -30,18 +32,28 @@ const DetailButton = ({ type }: DetailButtonProps) => {
       break;
     case 'payment':
       title = '입금';
-      description = '다음 입금일은 2025.01.12입니다.';
+      description = `다음 입금일은 ${nextDepositDate}입니다.`;
+      break;
+    case 'invite':
+      title = '학생 초대하기';
+      description = '초대링크를 공유해주세요';
       break;
   }
 
+  const isVisible = type !== 'payment' && type !== 'invite';
+
   return (
     <div
-      className="bg-slate-200 p-4 rounded-[20px] flex-col items-start flex gap-6 cursor-pointer"
+      className={`p-4 rounded-[20px] flex-col items-start flex gap-6 cursor-pointer ${
+        isPermission ? 'bg-slate-200 cursor-pointer' : 'bg-gray-300 opacity-50 cursor-not-allowed'
+      }`}
       onClick={() => {
-        nav(type);
+        if (isPermission) {
+          nav(type);
+        }
       }}
     >
-      {type !== 'payment' && <img src={강의자료함} className="h-[80px] w-[80px]"></img>}
+      {isVisible && <img src={강의자료함} className="h-[80px] w-[80px]" alt="강의자료함" />}
       <div className="m-0">
         <h3 className="text-[18px] font-bold">{title}</h3>
         <p className="text-[13px]">{description}</p>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -80,4 +80,37 @@ export const handlers = [
       },
     );
   }),
+
+  // 방 상세정보 가져오기
+  http.get('https://api.t-link.site/api/v1/rooms/:roomId', ({ params }) => {
+    const roomId = Array.isArray(params.roomId) ? params.roomId[0] : params.roomId;
+
+    if (!roomId) {
+      return HttpResponse.json({ error: 'Invalid roomId' }, { status: 400 });
+    }
+
+    return HttpResponse.json(
+      {
+        roomId: parseInt(roomId, 10), // `roomId`를 안전하게 정수로 변환
+        roomName: '중3 대현동',
+        studentName: '용가리',
+        subject: '수학',
+        lessonDays: ['월', '수'],
+        nextDepositDate: '2025-02-03',
+        permission: {
+          lecture_files: true,
+          homework: true,
+          gradeStatistic: true,
+          counselingLog: true,
+          deposit: true,
+        },
+      },
+      {
+        status: 200, // 성공 상태 코드
+        headers: {
+          'Access-Control-Allow-Origin': '*', // CORS 설정
+        },
+      },
+    );
+  }),
 ];

--- a/src/pages/RoomDetail.tsx
+++ b/src/pages/RoomDetail.tsx
@@ -1,15 +1,84 @@
+import { useEffect, useState } from 'react';
 import DetailButton from '../components/DetailButton';
+import instance from '../api/axios';
+import { useParams } from 'react-router-dom';
+import { SimpleLessonDay, SimplePermission } from '../models/room.model';
+
+interface RoomDetail {
+  roomId: number;
+  roomName: string;
+  studentName: string;
+  subject: string;
+  lessonDays: SimpleLessonDay[];
+  nextDepositDate: string;
+  permission: SimplePermission;
+}
+
 const RoomDetail = () => {
+  const { roomId } = useParams<{ roomId: string }>();
+  const [roomDetail, setRoomDetail] = useState<RoomDetail | null>(null);
+  useEffect(() => {
+    getRoomInfo();
+  }, [roomId]);
+
+  const getRoomInfo = async () => {
+    try {
+      // 확인용 mock data
+      const mockResponse = {
+        roomId: 1,
+        roomName: 'Mock Room',
+        studentName: 'John Doe',
+        subject: 'Math',
+        lessonDays: [{ lessonDay: 'Monday' }, { lessonDay: 'Wednesday' }], // 수정된 부분
+        nextDepositDate: '2025-01-31',
+        permission: {
+          lecture_file: true,
+          homework: true,
+          gradeStatistic: false,
+          counselingLog: true,
+          deposit: false,
+        },
+      };
+
+      setRoomDetail(mockResponse);
+
+      // const response = await instance.get(`/api/v1/rooms/${roomId}`);
+      // if (response.status == 200) {
+      //   setRoomDetail(response.data.data);
+      // }
+    } catch (error) {
+      console.log('방 정보 가젿오기 실패', error);
+    }
+  };
+
+  if (!roomDetail) {
+    return <div>로딩 중...</div>;
+  }
+
   return (
     <div className="px-4 flex-col flex gap-5">
-      <h2>100일 째 함께 공부중</h2>
+      <h2>{roomDetail.roomName}</h2>
+      <p>{`학생 이름: ${roomDetail.studentName}`}</p>
+      <p>{`과목: ${roomDetail.subject}`}</p>
+      <h3>수업 요일</h3>
+      <ul>
+        {roomDetail.lessonDays.map((day, index) => (
+          <li key={index}>{day.lessonDay}</li>
+        ))}
+      </ul>
       <div className="grid grid-cols-2 gap-4">
-        <DetailButton type="materials" />
-        <DetailButton type="homework" />
-        <DetailButton type="stats" />
-        <DetailButton type="diary" />
+        <DetailButton type="materials" isPermission={roomDetail.permission.lecture_file} />
+        <DetailButton type="homework" isPermission={roomDetail.permission.homework} />
+        <DetailButton type="stats" isPermission={roomDetail.permission.gradeStatistic} />
+        <DetailButton type="diary" isPermission={roomDetail.permission.counselingLog} />
       </div>
-      <DetailButton type="payment" />
+      <DetailButton
+        type="payment"
+        nextDepositDate={roomDetail.nextDepositDate}
+        isPermission={roomDetail.permission.deposit}
+      />
+      {/* role 보고 선생님이면 isPermission true */}
+      <DetailButton type="invite" isPermission={true} />
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Issues
#6 과외방 상세

## ✅ What to do
- [x] 권한에 따른 처리 구현
- [x] 과외방 상세 조회 API 연동
- [x] 학생 초대하기 컴포넌트 추가

## 📄 Description
* 과외방 상세 조회할 때 넘어오는 권한에 따라서 권한이 없는 경우는 회색 처리 후 클릭 막아놓았다.
* room.model에 있는 Interface들 사용했음
* 학생 초대하기 버튼은 권한말고 role에 따라 처리

## 🤔 Considerations
* room.model에 있는 Interface 중에 Room이랑 과외상세조회에서 설정한 Interface도 거의 비슷해서 room.model에 있는 interface를 수정해서 가져와도 괜찮을듯?

## 🛠️ Improvements to Make

개선할 사항

## 👀 References
![image](https://github.com/user-attachments/assets/ec506b74-a998-481b-8d34-18e513b60bf9)
