### PR TITLE
[Feat] 프로필 모달창 구현

### DIFF
--- a/src/api/roomList.api.ts
+++ b/src/api/roomList.api.ts
@@ -7,6 +7,12 @@ export const getRoomList = async () => {
   return res.data.rooms;
 };
 
+// 프로필 모달창 (프로픽 클릭 시)
+export const getProfileModal = async (userId: number) => {
+  const res = await instance.get(`/api/v1/users/${userId}/profile`);
+  return res.data;
+};
+
 // 과외방 정보 출력(수정 시)
 export const getCurrentRoomInfo = async (roomId: number) => {
   const res = await instance.get(`/api/v1/rooms/${roomId}/info`);

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -1,0 +1,53 @@
+import student from '../assets/images/student_boy.png';
+import DefaultProfile from '../assets/images/profile.svg?react';
+import { useEffect } from 'react';
+import { getProfileModal } from '../api/roomList.api';
+
+type ModalProps = {
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  id: number;
+};
+
+const ProfileModal = ({ setModalOpen, id }: ModalProps) => {
+  const userName = '김학생';
+  const userRole = '학생';
+  const userMent = '초6입니다람쥐';
+  const userPhone = '010-1234-5678';
+
+  /*
+  useEffect(() => {
+    const fetchProfileInfo = async () => {
+      const profileInfo = await getProfileModal(id);
+    };
+    fetchProfileInfo();
+  }, []);
+  */
+
+  return (
+    <div
+      className="fixed inset-0 bg-gray-500 bg-opacity-50 flex justify-center items-center z-50"
+      onClick={() => setModalOpen(false)} // 닫힘
+    >
+      <div
+        className="absolute top-10 flex flex-col py-5 w-1/3 h-3/5 bg-primary_100 rounded-[16px]"
+        onClick={(e) => e.stopPropagation()} // 닫힘 방지
+      >
+        <div className="flex justify-center gap-32 w-full">
+          <button onClick={() => setModalOpen(false)}>창 닫기</button>
+          <div className="flex bg-primary_50 rounded-[8px] py-2 px-3 gap-1">
+            <img src={student} className="w-6 h-6" />
+            <p className="text-body3 font-semibold text-primary_700 m-0">{userRole}</p>
+          </div>
+        </div>
+        <div className="flex flex-1 flex-col justify-center items-center">
+          <DefaultProfile />
+          <p className="text-[22px] font-bold leading-9 pt-6">{userName}</p>
+          <p className="text-caption1 leading-[22px] text-gray-500">{userMent}</p>
+          <p className="text-body3 tracking-[-0.048px] leading-7 text-gray-500">{userPhone}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileModal;

--- a/src/components/RoomInfo.tsx
+++ b/src/components/RoomInfo.tsx
@@ -4,6 +4,8 @@ import { SimpleRoomInfo } from '../models/room.model';
 import { useNavigate } from 'react-router-dom';
 import student_boy from '../assets/images/student_boy.png';
 import student_girl from '../assets/images/student_girl.png';
+import ProfileModal from './ProfileModal';
+import { useState } from 'react';
 
 type RoomProps = {
   room: SimpleRoomInfo;
@@ -11,11 +13,17 @@ type RoomProps = {
 };
 
 const RoomInfo = ({ room, handleDelete }: RoomProps) => {
+  const [modalOpen, setModalOpen] = useState(false);
   const navigate = useNavigate();
 
   return (
     <div className="flex items-center py-2.5 gap-4 px-4">
-      <div className="flex items-center p-1.5" style={{ backgroundColor: room.student.backgroundColor }}>
+      {modalOpen && <ProfileModal setModalOpen={setModalOpen} id={room.student.studentId} />}
+      <div
+        className="flex items-center p-1.5 cursor-pointer"
+        onClick={() => setModalOpen(true)}
+        style={{ backgroundColor: room.student.backgroundColor }}
+      >
         {room.student.gender === '남' ? (
           <img className="w-9 h-9" src={student_boy} />
         ) : (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,6 @@
-import teacher from '../assets/images/Teacher.png';
-import student from '../assets/images/Boy.png';
-import mom from '../assets/images/Mom.png';
+import teacher from '../assets/images/teacher_woman.png';
+import student from '../assets/images/student_boy.png';
+import mom from '../assets/images/parent_mom.png';
 import DefaultProfile from '../assets/images/profile.svg?react';
 import { FaAngleRight } from 'react-icons/fa6';
 


### PR DESCRIPTION
## 🔥 Issues

#19 

## ✅ What to do

- [x] 프로필 모달창 구현

## 📄 Description

![image](https://github.com/user-attachments/assets/69706b0c-b8fd-4b89-a16a-fd9ba7028d83)

학생 아이콘을 누르면 모달창이 나온다.
바깥부분을 누르면 모달창이 꺼지고 바깥 부분의 다른 기능은 사용할 수 없다.

## 🤔 Considerations
1. 모달창 css 구현 고민
-> fixed, absolute를 사용.
-> inset-0으로 top, right, bottom, left를 모두 0으로 설정하여  배경이 화면 전체를 차지하도록 함.
-> z-50로 모달이 다른 UI 요소보다 위에 표시되도록 함

2. 바깥 부분을 누르면 모달창이 종료되도록 하였는데 모달 내부를 눌렀을 때도 종료가 된다.
-> e.stopPropagation()를 이용하여 이벤트가 상위 DOM으로 전파되지 않도록 막는다.

## 🛠️ Improvements to Make

API 받아오는 부분 수정해야 할 것 같다.
디자인 완성되면 UI 수정해야 한다.

## 👀 References

https://bolob.tistory.com/entry/JavaScript-epreventDefault%EC%99%80-estopPropagation%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90

https://joylee-developer.tistory.com/184