### PR TITLE
[Feat] 상담 일지

### DIFF
--- a/src/api/counseling.api.ts
+++ b/src/api/counseling.api.ts
@@ -12,3 +12,9 @@ export const postCounselingLogs = async (roomId: string, payload: CounselingInfo
   const response = await instance.post(`/api/v1/rooms/${roomId}/counselingLogs`, payload);
   return response.data;
 };
+
+// 상담 일지 상세 조회
+export const getCounselingLogDetail = async (roomId: string, counselingLogId: string) => {
+  const response = await instance.get(`/api/v1/rooms/${roomId}/counselingLogs/${counselingLogId}`);
+  return response.data;
+};

--- a/src/api/counseling.api.ts
+++ b/src/api/counseling.api.ts
@@ -1,7 +1,14 @@
+import { CounselingInfo } from '../models/counseling.model';
 import instance from './axios';
 
 // 상담 일지 목록 조회
 export const getCounselingLogs = async (roomId: string) => {
   const response = await instance.get(`/api/v1/rooms/${roomId}/counselingLogs`);
+  return response.data;
+};
+
+// 상담 일지 업로드
+export const postCounselingLogs = async (roomId: string, payload: CounselingInfo) => {
+  const response = await instance.post(`/api/v1/rooms/${roomId}/counselingLogs`, payload);
   return response.data;
 };

--- a/src/api/counseling.api.ts
+++ b/src/api/counseling.api.ts
@@ -1,0 +1,7 @@
+import instance from './axios';
+
+// 상담 일지 목록 조회
+export const getCounselingLogs = async (roomId: string) => {
+  const response = await instance.get(`/api/v1/rooms/${roomId}/counselingLogs`);
+  return response.data;
+};

--- a/src/api/counseling.api.ts
+++ b/src/api/counseling.api.ts
@@ -18,3 +18,15 @@ export const getCounselingLogDetail = async (roomId: string, counselingLogId: st
   const response = await instance.get(`/api/v1/rooms/${roomId}/counselingLogs/${counselingLogId}`);
   return response.data;
 };
+
+// 상담 일지 삭제
+export const deleteCounselingLog = async (roomId: string, counselingLogId: string) => {
+  const response = await instance.delete(`/api/v1/rooms/${roomId}/counselingLogs/${counselingLogId}`);
+  return response.data;
+};
+
+// 상담 일지 수정
+export const patchCounselingLog = async (roomId: string, counselingLogId: string, payload: CounselingInfo) => {
+  const response = await instance.put(`/api/v1/rooms/${roomId}/counselingLogs/${counselingLogId}`, payload);
+  return response.data;
+};

--- a/src/models/counseling.model.ts
+++ b/src/models/counseling.model.ts
@@ -5,11 +5,11 @@ export interface CounselingLogs {
   updatedAt: string;
 }
 
-// 상담일지 업로드
+// 상담일지 업로드 && 수정
 export interface CounselingInfo {
   title: string;
   content: string;
-  engagement: 'upper' | 'middle' | 'lower';
+  engagement: string;
   homeworkSubmitted: boolean | null;
 }
 

--- a/src/models/counseling.model.ts
+++ b/src/models/counseling.model.ts
@@ -10,5 +10,15 @@ export interface CounselingInfo {
   title: string;
   content: string;
   engagement: 'upper' | 'middle' | 'lower';
-  homeworkSubmitted?: boolean;
+  homeworkSubmitted: boolean | null;
+}
+
+// 상담일지 상세 조회
+export interface CounselingLogDetail {
+  counselingLogId: number;
+  title: string;
+  content: string;
+  engagement: string;
+  homeworkSubmitted: boolean | null;
+  updatedAt: string;
 }

--- a/src/models/counseling.model.ts
+++ b/src/models/counseling.model.ts
@@ -4,3 +4,11 @@ export interface CounselingLogs {
   title: string;
   updatedAt: string;
 }
+
+// 상담일지 업로드
+export interface CounselingInfo {
+  title: string;
+  content: string;
+  engagement: 'upper' | 'middle' | 'lower';
+  homeworkSubmitted?: boolean;
+}

--- a/src/models/counseling.model.ts
+++ b/src/models/counseling.model.ts
@@ -1,0 +1,6 @@
+// 상담일지 목록 조회 시 사용
+export interface CounselingLogs {
+  counselingLogId: number;
+  title: string;
+  updatedAt: string;
+}

--- a/src/pages/Counseling/CounselingDetail.tsx
+++ b/src/pages/Counseling/CounselingDetail.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { FaRegCheckCircle, FaRegTimesCircle } from 'react-icons/fa';
+import { RiEmotionHappyLine, RiEmotionNormalLine, RiEmotionUnhappyLine } from 'react-icons/ri';
+import { useParams } from 'react-router-dom';
+import { CounselingLogDetail } from '../../models/counseling.model';
+import { getCounselingLogDetail } from '../../api/counseling.api';
+
+const CounselingDetail = () => {
+  const { roomId, counselingId } = useParams<{ roomId: string; counselingId: string }>();
+  const [counselingDetail, setCounselingDetail] = useState<CounselingLogDetail>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    getCounselingDetail();
+  }, [counselingId, roomId]);
+
+  const getCounselingDetail = async () => {
+    try {
+      const mockData = {
+        counselingLogId: 1,
+        title: '중간고사 피드백',
+        content: '중간고사를 넘 잘봣어요~',
+        engagement: 'upper',
+        homeworkSubmitted: null,
+        updatedAt: '2025.01.07',
+      };
+      setCounselingDetail(mockData);
+      //   const response = await getCounselingLogDetail(roomId!, counselingId!);
+      //   setCounselingDetail(response.data);
+    } catch (error) {
+      console.log('상세 조회 실패');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (!counselingDetail) {
+    return <div>데이터를 불러오지 못했습니다.</div>;
+  }
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div>
+        <div>{counselingDetail.title}</div>
+        <p>{counselingDetail.updatedAt}</p>
+      </div>
+      <div className="flex border border-black mx-3 flex-col my-5 h-full">
+        <div className="flex items-center gap-1">
+          <p>참여도</p>
+          <RiEmotionHappyLine className={`${counselingDetail.engagement == 'upper' ? 'fill-primary_500' : ''}`} />
+          <RiEmotionNormalLine className={`${counselingDetail.engagement == 'middle' ? 'fill-primary_500' : ''}`} />
+          <RiEmotionUnhappyLine className={`${counselingDetail.engagement == 'lower' ? 'fill-primary_500' : ''}`} />
+        </div>
+        <div className="flex items-center gap-1">
+          <p>과제 제출 여부</p>
+          <FaRegCheckCircle className={`${counselingDetail.homeworkSubmitted ? 'fill-primary_500' : ''}`} />
+          <FaRegTimesCircle className={`${!counselingDetail.homeworkSubmitted ? 'fill-primary_500' : ''}`} />
+        </div>
+        <div className="mx-3 resize-none h-full my-6 border border-gray-300">{counselingDetail.content}</div>
+      </div>
+      <div className="flex justify-end">
+        <button className="bg-primary_400 w-20">수정</button>
+      </div>
+    </div>
+  );
+};
+
+export default CounselingDetail;

--- a/src/pages/Counseling/CounselingDetail.tsx
+++ b/src/pages/Counseling/CounselingDetail.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { FaRegCheckCircle, FaRegTimesCircle } from 'react-icons/fa';
 import { RiEmotionHappyLine, RiEmotionNormalLine, RiEmotionUnhappyLine } from 'react-icons/ri';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { CounselingLogDetail } from '../../models/counseling.model';
-import { getCounselingLogDetail } from '../../api/counseling.api';
+import { deleteCounselingLog, getCounselingLogDetail } from '../../api/counseling.api';
 
 const CounselingDetail = () => {
+  const nav = useNavigate();
   const { roomId, counselingId } = useParams<{ roomId: string; counselingId: string }>();
   const [counselingDetail, setCounselingDetail] = useState<CounselingLogDetail>();
   const [isLoading, setIsLoading] = useState(true);
@@ -31,6 +32,23 @@ const CounselingDetail = () => {
       console.log('상세 조회 실패');
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleModify = () => {
+    nav(`/user/roomlist/${roomId}/diary/create?isEdit=true`, { state: { counselingDetail } });
+  };
+
+  // 삭제
+  const handleDelete = async () => {
+    try {
+      const response = await deleteCounselingLog(roomId!, counselingId!);
+      if (response.status == 200) {
+        console.log('삭제 성공');
+        nav(-1);
+      }
+    } catch (error) {
+      console.log('삭제 실패');
     }
   };
 
@@ -62,7 +80,12 @@ const CounselingDetail = () => {
         <div className="mx-3 resize-none h-full my-6 border border-gray-300">{counselingDetail.content}</div>
       </div>
       <div className="flex justify-end">
-        <button className="bg-primary_400 w-20">수정</button>
+        <button className="bg-primary_400 w-20" onClick={handleModify}>
+          수정
+        </button>
+        <button className="bg-red-400 w-20" onClick={handleDelete}>
+          삭제
+        </button>
       </div>
     </div>
   );

--- a/src/pages/Counseling/CounselingDiary.tsx
+++ b/src/pages/Counseling/CounselingDiary.tsx
@@ -1,5 +1,58 @@
+import { useEffect, useState } from 'react';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { CounselingLogs } from '../../models/counseling.model';
+import { getCounselingLogs } from '../../api/counseling.api';
+
 const CounselingDiary = () => {
-  return <div>CounselingDiary</div>;
+  const { roomId } = useParams<{ roomId: string }>();
+  const [counselingList, setCounselingList] = useState<CounselingLogs[]>([]);
+  const nav = useNavigate();
+
+  useEffect(() => {
+    getCounselingDiary();
+  }, []);
+
+  // 상담일지 목록 조회
+  const getCounselingDiary = async () => {
+    try {
+      // 확인용 mockData
+      const mockData = [
+        { counselingLogId: 1, title: '중간고사 피드백', updatedAt: '2024-04-04' },
+        { counselingLogId: 2, title: '숙제를 너무 안해옵니다...', updatedAt: '2024-05-05' },
+        { counselingLogId: 3, title: '수업을 요즘 잘들어요~', updatedAt: '2024-06-06' },
+      ];
+
+      setCounselingList(mockData);
+      // const data = await getCounselingLogs(roomId!);
+      // setCounselingList(data.counselingLogs);
+    } catch (error) {
+      console.log('강의 자료 목록 조회 실패', error);
+    }
+  };
+
+  return (
+    <div>
+      {counselingList.map((logs) => (
+        <div
+          key={logs.counselingLogId}
+          className="border p-4 rounded mb-2 cursor-pointer"
+          onClick={() => nav(`${logs.counselingLogId}`)}
+        >
+          <h3 className="font-bold">상담제목: {logs.title}</h3>
+          <p>날짜: {logs.updatedAt}</p>
+        </div>
+      ))}
+      <button
+        className="bg-primary_500"
+        onClick={() => {
+          nav('create');
+        }}
+      >
+        +상담일지
+      </button>
+      <Outlet />
+    </div>
+  );
 };
 
 export default CounselingDiary;

--- a/src/pages/Counseling/CreateCounseling.tsx
+++ b/src/pages/Counseling/CreateCounseling.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { RiEmotionHappyLine } from 'react-icons/ri';
+import { RiEmotionNormalLine } from 'react-icons/ri';
+import { RiEmotionUnhappyLine } from 'react-icons/ri';
+import { FaRegCheckCircle } from 'react-icons/fa';
+import { FaRegTimesCircle } from 'react-icons/fa';
+import { postCounselingLogs } from '../../api/counseling.api';
+import { useNavigate, useParams } from 'react-router-dom';
+
+const CreateCounseling = () => {
+  const nav = useNavigate();
+  const { roomId } = useParams<{ roomId: string }>();
+
+  const formatDate = (date: Date) => `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+  const todayFormatted = formatDate(new Date());
+
+  const [title, setTitle] = useState('');
+  const [engagement, setEngagement] = useState<'upper' | 'middle' | 'lower'>('upper');
+  const [homeworkSubmitted, setHomeworkSubmitted] = useState<boolean>();
+  const [content, setContent] = useState<string>('');
+
+  const isValidForm = () => {
+    if (!title.trim()) return '제목을 입력해주세요!';
+    if (!engagement) return '참여도를 선택해주세요!';
+    if (!content.trim()) return '내용을 입력해주세요!';
+    return '';
+  };
+
+  const handleSubmit = async () => {
+    const error = isValidForm();
+    if (error) {
+      alert(error);
+      return;
+    }
+
+    const payload = {
+      title: title,
+      content: content,
+      engagement: engagement,
+      homeworkSubmitted: homeworkSubmitted,
+    };
+
+    try {
+      const response = await postCounselingLogs(roomId!, payload);
+      if (response.status == 200) {
+        console.log('상담일지 업로드 성공');
+        nav(-1);
+      }
+    } catch (error) {
+      console.log('상담일지 업로드 실패');
+    }
+  };
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div>
+        <input placeholder="상담 제목을 입력해주세요" onChange={(e) => setTitle(e.target.value)} value={title}></input>
+        <p>{todayFormatted}</p>
+      </div>
+      <div className="flex border border-black mx-3 flex-col my-5 h-full">
+        <div className="flex items-center gap-1">
+          <p>참여도</p>
+          <RiEmotionHappyLine
+            onClick={() => {
+              setEngagement('upper');
+            }}
+            className={`${engagement == 'upper' ? 'fill-primary_500' : ''}`}
+          />
+          <RiEmotionNormalLine
+            onClick={() => {
+              setEngagement('middle');
+            }}
+            className={`${engagement == 'middle' ? 'fill-primary_500' : ''}`}
+          />
+          <RiEmotionUnhappyLine
+            onClick={() => {
+              setEngagement('lower');
+            }}
+            className={`${engagement == 'lower' ? 'fill-primary_500' : ''}`}
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          <p>과제 제출 여부</p>
+          <FaRegCheckCircle
+            onClick={() => {
+              setHomeworkSubmitted(true);
+            }}
+            className={`${homeworkSubmitted ? 'fill-primary_500' : ''}`}
+          />
+          <FaRegTimesCircle
+            onClick={() => {
+              setHomeworkSubmitted(false);
+            }}
+            className={`${!homeworkSubmitted ? 'fill-primary_500' : ''}`}
+          />
+        </div>
+        <textarea
+          className="mx-3 resize-none h-full my-6 border border-gray-300"
+          placeholder="상담내용"
+          onChange={(e) => setContent(e.target.value)}
+          value={content}
+        ></textarea>
+      </div>
+      <div className="flex justify-end">
+        <button className="bg-primary_400 w-20" onClick={handleSubmit}>
+          완료
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CreateCounseling;

--- a/src/pages/Counseling/CreateCounseling.tsx
+++ b/src/pages/Counseling/CreateCounseling.tsx
@@ -4,20 +4,26 @@ import { RiEmotionNormalLine } from 'react-icons/ri';
 import { RiEmotionUnhappyLine } from 'react-icons/ri';
 import { FaRegCheckCircle } from 'react-icons/fa';
 import { FaRegTimesCircle } from 'react-icons/fa';
-import { postCounselingLogs } from '../../api/counseling.api';
-import { useNavigate, useParams } from 'react-router-dom';
+import { patchCounselingLog, postCounselingLogs } from '../../api/counseling.api';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const CreateCounseling = () => {
   const nav = useNavigate();
   const { roomId } = useParams<{ roomId: string }>();
 
+  const location = useLocation();
+  const isEdit = new URLSearchParams(location.search).get('isEdit') === 'true';
+  const initialData = location.state?.counselingDetail;
+
   const formatDate = (date: Date) => `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
   const todayFormatted = formatDate(new Date());
 
-  const [title, setTitle] = useState('');
-  const [engagement, setEngagement] = useState<'upper' | 'middle' | 'lower'>('upper');
-  const [homeworkSubmitted, setHomeworkSubmitted] = useState<boolean>();
-  const [content, setContent] = useState<string>('');
+  const [title, setTitle] = useState<string>(isEdit ? initialData.title : '');
+  const [content, setContent] = useState<string>(isEdit ? initialData.content : '');
+  const [engagement, setEngagement] = useState<string>(isEdit ? initialData.engagement : 'upper');
+  const [homeworkSubmitted, setHomeworkSubmitted] = useState<boolean | null>(
+    isEdit ? initialData.homeworkSubmitted : null,
+  );
 
   const isValidForm = () => {
     if (!title.trim()) return '제목을 입력해주세요!';
@@ -26,6 +32,7 @@ const CreateCounseling = () => {
     return '';
   };
 
+  // 생성 및 수정
   const handleSubmit = async () => {
     const error = isValidForm();
     if (error) {
@@ -41,13 +48,21 @@ const CreateCounseling = () => {
     };
 
     try {
-      const response = await postCounselingLogs(roomId!, payload);
-      if (response.status == 200) {
-        console.log('상담일지 업로드 성공');
-        nav(-1);
+      if (isEdit) {
+        const response = await patchCounselingLog(roomId!, initialData.counselingLogId, payload);
+        if (response.status == 200) {
+          console.log('상담일지 수정 성공');
+          nav(`/user/roomlist/${roomId}/diary/${initialData.counselingLogId}`);
+        }
+      } else {
+        const response = await postCounselingLogs(roomId!, payload);
+        if (response.status == 200) {
+          console.log('상담일지 업로드 성공');
+          nav(`/user/roomlist/${roomId}/diary`);
+        }
       }
     } catch (error) {
-      console.log('상담일지 업로드 실패');
+      console.log(isEdit ? '수정 실패' : '생성 실패', error);
     }
   };
 
@@ -55,7 +70,7 @@ const CreateCounseling = () => {
     <div className="flex flex-col w-full h-full">
       <div>
         <input placeholder="상담 제목을 입력해주세요" onChange={(e) => setTitle(e.target.value)} value={title}></input>
-        <p>{todayFormatted}</p>
+        <p>{isEdit ? initialData.updatedAt : todayFormatted}</p>
       </div>
       <div className="flex border border-black mx-3 flex-col my-5 h-full">
         <div className="flex items-center gap-1">
@@ -103,7 +118,7 @@ const CreateCounseling = () => {
       </div>
       <div className="flex justify-end">
         <button className="bg-primary_400 w-20" onClick={handleSubmit}>
-          완료
+          {isEdit ? '수정 완료' : '생성 완료'}
         </button>
       </div>
     </div>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -24,6 +24,7 @@ import HomeworkDetail from '../pages/Homework/HomeworkDetail';
 import MaterialDetail from '../pages/Material/MaterialDetail';
 import CounselingDiary from '../pages/Counseling/CounselingDiary';
 import CreateCounseling from '../pages/Counseling/CreateCounseling';
+import CounselingDetail from '../pages/Counseling/CounselingDetail';
 
 export const router = createBrowserRouter([
   {
@@ -68,6 +69,7 @@ export const router = createBrowserRouter([
               { path: 'stats', element: <Statistics /> },
               { path: 'diary', element: <CounselingDiary /> }, // 상담 일지
               { path: 'diary/create', element: <CreateCounseling /> }, // 상담 일지 업로드
+              { path: 'diary/:counselingId', element: <CounselingDetail /> }, // 상담 일지 상세
               { path: 'payment', element: <Payment /> },
             ],
           },

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -23,6 +23,7 @@ import CreateHomework from '../pages/Homework/CreateHomework';
 import HomeworkDetail from '../pages/Homework/HomeworkDetail';
 import MaterialDetail from '../pages/Material/MaterialDetail';
 import CounselingDiary from '../pages/Counseling/CounselingDiary';
+import CreateCounseling from '../pages/Counseling/CreateCounseling';
 
 export const router = createBrowserRouter([
   {
@@ -66,6 +67,7 @@ export const router = createBrowserRouter([
               { path: 'homework/:homeworkId', element: <HomeworkDetail /> }, // 숙제 상세
               { path: 'stats', element: <Statistics /> },
               { path: 'diary', element: <CounselingDiary /> }, // 상담 일지
+              { path: 'diary/create', element: <CreateCounseling /> }, // 상담 일지 업로드
               { path: 'payment', element: <Payment /> },
             ],
           },


### PR DESCRIPTION
## 🔥 Issues
#46 

## ✅ What to do
- [x] 상담일지 목록 조회
- [x] 상담일지 작성
- [x] 상담일지 수정
- [x] 상담일지 삭제
- [x] 상담일지 상세조회

## 📄 Description
* 상담일지 페이지에서 목록 조회와 생성이 가능하며, 개별 항목을 클릭하면 상세 조회로 이동.
* 상세 조회 페이지에서 상담일지 삭제 및 수정이 가능.
* 수정 버튼 클릭 시 생성 페이지로 이동하여 수정 작업을 진행.

## 🤔 Considerations
* 상담일지 생성과 수정의 UI가 거의 동일해서, 수정 페이지를 별도로 만들지 조건부 렌더링을 사용할지 고민했음.
* UI는 동일하고 차이점은 기본값이 있느냐 없느냐뿐이어서 조건부 렌더링을 선택.
  * 상세 페이지에서 수정 버튼 클릭 시 useNavigate로 생성 페이지로 이동하며, 경로에 ?isEdit=true를 추가하고, state로 상세 조회 시 가져온 counselingDetail 객체를 전달.
  * 생성 페이지는 useLocation과 useParams로 isEdit 값을 확인하고, state로 전달된 데이터를 초기 값으로 설정하여 입력 필드에 적용.
* 상세 조회와 생성 페이지는 UI가 유사하지만, 사용 방식(읽기/쓰기)이 다르고, 생성 페이지는 이미 수정과 조건부 렌더링을 처리 중이기 때문에 상세 조회까지 합치면 너무 복잡해질 것 같음
  * 상세 조회와 생성/수정 페이지를 분리.

## 🛠️ Improvements to Make
* 강의 자료함과 숙제방, 상담일지 목록을 불러오는 페이지에서 컴포넌트들이 비슷할 것 같아서, 디자인이 나오면 이 컴포넌트를 따로 분리해서 쓰면 좋을듯

## 👀 References
https://jofestudio.tistory.com/66
