### PR TITLE
[Fix] 모바일 화면에서 스크롤 문제 해결

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,6 +8,9 @@ const Layout = () => {
   const headerHeight = useRef<HTMLDivElement>(null);
   const navBarHeight = useRef<HTMLDivElement>(null);
   const [heights, setHeights] = useState({ header: 0, navbar: 0 });
+  const clientHeight = document.documentElement.clientHeight;
+
+  console.log(clientHeight);
 
   useEffect(() => {
     if (headerHeight.current && navBarHeight.current) {
@@ -18,7 +21,7 @@ const Layout = () => {
   }, []);
 
   return (
-    <div className="flex flex-col min-h-screen scrollbar-none">
+    <div className="flex flex-col">
       <div className="fixed w-full max-w-[500px]" ref={headerHeight}>
         <Header />
       </div>
@@ -27,8 +30,7 @@ const Layout = () => {
         style={{
           marginTop: `${heights.header}px`,
           marginBottom: `${heights.navbar}px`,
-          // 이거 100vh로 안하고 이걸로 햇는데... 딱히 적용이 안되는 것 같아서 나중에 확인해봐야함.
-          height: `calc(100vh - ${heights.header + heights.navbar}px)`,
+          height: `calc(100dvh - ${heights.header + heights.navbar}px)`,
         }}
       >
         <Outlet />

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -38,7 +38,7 @@ const NavBar = () => {
   ];
 
   return (
-    <div className="border-t border-gray-200 flex">
+    <div className="border-t border-gray-200 flex bg-white">
       <div className="grid grid-cols-3 w-full px-[7.5px]">
         {menus.map((menuItem) => (
           <div


### PR DESCRIPTION
## 🔥 Issues


## ✅ What to do

- [x] 모바일 화면에서 스크롤 문제 해결

## 📄 Description


## 🤔 Considerations
* 모바일에서 페이지 레이아웃 문제를 확인한 결과, 스크린 크기가 커서 레이아웃 계산이 제대로 이루어지지 않아 스크롤이 되지 않고, 페이지가 짤리는 문제가 있었다...
* Layout 컴포넌트에서 min-h-screen을 사용하면서 높이가 100vh로 계산되었기 때문... 
* 이를 해결하기 위해 Layout 컴포넌트에서 min-h-screen을 지우고 헤더와 네브바를 제외한 나머지 영역의 높이를 지정할 때, 100dvh를 사용하도록 수정했더니 문제가 해결되었다!


## 🛠️ Improvements to Make


## 👀 References

스크린샷 또는 참고사항
