### PR TITLE
[Fix] NavBar 경로 기반으로 수정

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import CalendarSvg from '../assets/images/calendar.svg?react';
 import CalendarFill from '../assets/images/calendarFill.svg?react';
@@ -9,12 +9,15 @@ import MypageSvg from '../assets/images/mypage.svg?react';
 import MyPageFill from '../assets/images/mypageFill.svg?react';
 import Indicator from '../assets/images/Indicator.svg?react';
 
-// useLocationd을 사용해 경로로 접근하는 방식도 고려 필요
-// 경로로 접근할 일은 없으니 상관없나?
-
 const NavBar = () => {
   const nav = useNavigate();
+  const location = useLocation();
   const [currentMenu, setCurrentMenu] = useState<string>('roomlist');
+
+  useEffect(() => {
+    const pathname = location.pathname.split('/');
+    setCurrentMenu(pathname[2]);
+  }, [location]);
 
   const menus = [
     {
@@ -45,7 +48,6 @@ const NavBar = () => {
             key={menuItem.name}
             className={`flex-col cursor-pointer px-4 flex items-center ${currentMenu === menuItem.name ? 'pt-[6px] pb-[0px]' : 'py-[6px]'}`}
             onClick={() => {
-              setCurrentMenu(menuItem.name);
               nav(menuItem.name);
             }}
           >


### PR DESCRIPTION
## 🔥 Issues
#8 

## ✅ What to do

- [x] 선택된 메뉴를 경로 기반으로 수정

## 📄 Description
* 기존에는 `onClick` 이벤트를 이용해 현재 메뉴를 변경했음.
* 하지만 달력에서 과외방으로 `useNavigate`를 사용해 이동할 때, `navBar`가 변경되지 않는 문제가 발생하여 `useLocation`을 사용해 경로 기반으로 메뉴를 변경하도록 수정함.

## 🤔 Considerations
* `useLocation`을 사용하면 `/user/roomlist`처럼 전체 `pathname`이 반환됨.
* 하지만 필요한 부분은 마지막 경로(`roomlist`)이므로, `split('/')`을 사용하여 생성된 `["", "user", "roomlist"]` 배열에서, 두 번째 요소(`roomlist`)를 가져오도록 수정함.


## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
