### PR TITLE
[Fix] 헤더 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,71 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { GoArrowLeft } from 'react-icons/go';
+import { useEffect, useState } from 'react';
 
 const Header = () => {
   const navigate = useNavigate();
+  const location = useLocation().pathname;
+
+  const [left, setLeft] = useState(false);
+  const [title, setTitle] = useState('');
+  const [border, setBorder] = useState(true);
+
+  useEffect(() => {
+    if (location.includes('/materials')) {
+      setTitle('강의 자료함');
+      setLeft(true);
+    } else if (location.includes('/homework')) {
+      setTitle('주차별 숙제');
+      setLeft(true);
+    } else if (location.includes('/diary')) {
+      setTitle('상담일지');
+      setLeft(true);
+    } else if (location.startsWith('/user/roomlist/')) {
+      setTitle('과외방 상세');
+      setLeft(true);
+    } else {
+      switch (location) {
+        case '/user/mypage':
+          setTitle('내 정보');
+          setLeft(false);
+          break;
+        case '/user/calendar':
+          setTitle('달력');
+          setLeft(false);
+          break;
+        case '/user/roomlist':
+          setTitle('과외방');
+          setLeft(false);
+          break;
+        case '/user/mypage/terms':
+          setTitle('이용약관');
+          setLeft(true);
+          break;
+        case '/signup':
+        case '/formbasic':
+        case '/formtel':
+          setLeft(true);
+          setBorder(false);
+          break;
+        default:
+          setTitle('');
+          break;
+      }
+    }
+  }, [location]);
+
   return (
-    <div className="flex items-center px-2 py-1.5">
-      <div className="flex p-2.5 justify-center items-center cursor-pointer" onClick={() => navigate(-1)}>
-        <GoArrowLeft size={24} />
+    <div className={`flex items-center py-2 px-1.5 ${border ? 'border-b-2' : 'border-0'} border-b-gray-100`}>
+      <div
+        className={`flex w-11 h-11 justify-center items-center ${left ? 'cursor-pointer' : ''} `}
+        onClick={() => {
+          left ? navigate(-1) : '';
+        }}
+      >
+        {left && <GoArrowLeft size={24} />}
       </div>
-      <div className="flex-1 text-center">t-link</div>
-      <div className="w-11" />
+      <div className="flex-1 text-center font-semibold text-lg">{title}</div>
+      <div className="w-11 h-11" />
     </div>
   );
 };

--- a/src/pages/UserPolicy.tsx
+++ b/src/pages/UserPolicy.tsx
@@ -7,6 +7,7 @@ import TopButton from '../assets/images/Top Button.svg?react';
 import { useEffect, useState } from 'react';
 import Modal from '../components/Modal/Modal';
 import LogoutModal, { MODAL_TYPE } from '../components/Modal/LogoutModal';
+import Header from '../components/Header';
 
 const UserPolicy = () => {
   const nav = useNavigate();
@@ -57,14 +58,8 @@ const UserPolicy = () => {
   return (
     <div className="flex flex-col mb-[62px]">
       {/* 헤더 */}
-      <div className="fixed py-2 px-[6px] border-b-2 border-gray-100 flex items-center bg-white w-full max-w-[500px]">
-        <div className="flex p-2.5 justify-center items-center cursor-pointer" onClick={() => nav(-1)}>
-          <GoArrowLeft size={24} />
-        </div>
-        <div className="flex-1 text-center text-body2 font-semibold leading-6 tracking-[-0.27px]">이용약관</div>
-        <div className="w-11" />
-      </div>
-      <div className="flex flex-col mt-[62px]">
+      <Header />
+      <div className="flex flex-col">
         {/* 이용약관 */}
         <div className="p-4 border-b-2 border-gray-100 flex flex-col gap-2 tracking-[-0.048px] leading-7 text-body3">
           <p className="font-semibold ">1. 비즈니스 파트너 개인정보 처리방침</p>


### PR DESCRIPTION
## 🔥 Issues

#8 

## ✅ What to do

- [x] 헤더 수정

## 📄 Description

useLocation을 이용하여 페이지마다 title을 설정해주었다.
- left가 true이면 왼쪽에 화살표 추가 / false이면 화살표 없앰
- title: 헤더 가운데 보이는 페이지명
- border가 true이면 border-b 추가 / false이면 border-b 없앰
-> 기본이 border-b 있고 signup만 없어서 추가함.
-> border-b 있는 페이지는 따로 setBorder() 안해도 됨.

## 🤔 Considerations

상세 페이지는 뒤에 Id가 붙어서 어떻게 해야하지? 
-> startsWith, includes로 상세페이지 구분.

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
