### PR TITLE
[Feat] 과외방 초대 링크 기능 구현

### DIFF
--- a/src/components/DetailButton.tsx
+++ b/src/components/DetailButton.tsx
@@ -1,5 +1,7 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import 강의자료함 from '/강의자료함.png';
+import { useEffect, useState } from 'react';
+import Toast from './Toast';
 
 interface DetailButtonProps {
   type: string;
@@ -10,6 +12,10 @@ interface DetailButtonProps {
 const DetailButton = ({ type, nextDepositDate, isPermission }: DetailButtonProps) => {
   let title = '';
   let description = '';
+
+  const [code, setCode] = useState('');
+  const [toast, setToast] = useState(false);
+  const { roomId } = useParams();
 
   const nav = useNavigate();
 
@@ -34,25 +40,40 @@ const DetailButton = ({ type, nextDepositDate, isPermission }: DetailButtonProps
       title = '입금';
       description = `다음 입금일은 ${nextDepositDate}입니다.`;
       break;
-    case 'invite':
+    case 'sharecode':
       title = '학생 초대하기';
       description = '초대링크를 공유해주세요';
       break;
   }
 
-  const isVisible = type !== 'payment' && type !== 'invite';
+  const isVisible = type !== 'payment' && type !== 'sharecode';
+
+  useEffect(() => {
+    setCode(`http://localhost:5173/user/roomlist/${roomId}/invite`);
+  }, [roomId]);
+
+  const handleClick = async () => {
+    if (type === 'sharecode') {
+      try {
+        await navigator.clipboard.writeText(code);
+        setToast(true);
+      } catch (e) {
+        alert('초대 코드 복사에 실패했습니다.');
+      }
+    } else if (isPermission) {
+      nav(type);
+    }
+  };
 
   return (
     <div
       className={`p-4 rounded-[20px] flex-col items-start flex gap-6 cursor-pointer ${
         isPermission ? 'bg-slate-200 cursor-pointer' : 'bg-gray-300 opacity-50 cursor-not-allowed'
       }`}
-      onClick={() => {
-        if (isPermission) {
-          nav(type);
-        }
-      }}
+      onClick={handleClick}
     >
+      {toast && <Toast setToast={setToast} />}
+
       {isVisible && <img src={강의자료함} className="h-[80px] w-[80px]" alt="강의자료함" />}
       <div className="m-0">
         <h3 className="text-[18px] font-bold">{title}</h3>

--- a/src/components/Modal/InviteModal.tsx
+++ b/src/components/Modal/InviteModal.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type ModalProps = {
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  id: number;
+};
+
+const InviteModal = ({ setModalOpen, id }: ModalProps) => {
+  const navigation = useNavigate();
+  const [status, setStatus] = useState(false);
+  const [message, setMessage] = useState('');
+  const handleAccept = () => {
+    /* '네"를 눌렀을 때
+    학생 Id, 방 Id(이건 백에서 정해주세요)를 넘겨주면 백에서 학생이 이미 들어가있는지 확인 후 
+    백 -> 프론트 경우 나눠서 알려줌
+
+    // 이미 들어가 있는 경우
+    if(status) {
+    setMessage("이미 초대 되었습니다.");
+    }
+    // 안 들어간 경우
+    else {
+    setMessage("초대 완료 되었습니다.");
+    }
+
+    navigation('/user/roomlist');
+    */
+  };
+
+  return (
+    <div className="flex flex-col py-5 w-1/3 min-w-[300px] h-1/5 bg-white rounded-[16px]">
+      <div className="flex flex-1 flex-col justify-center items-center">
+        oo님이 과외방으로 초대하셨습니다. <br /> 입장하시겠습니까?
+      </div>
+      <div className="flex justify-center gap-32 w-full">
+        <button onClick={handleAccept}>네</button>
+        <button onClick={() => navigation('/user/roomlist')}>아니요</button>
+      </div>
+    </div>
+  );
+};
+
+export default InviteModal;

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -28,10 +28,7 @@ const ProfileModal = ({ setModalOpen, id }: ModalProps) => {
   */
 
   return (
-    <div
-      className="flex flex-col py-5 w-1/3 min-w-[300px] h-3/5 bg-primary_100 rounded-[16px]"
-      onClick={(e) => e.stopPropagation()} // 닫힘 방지
-    >
+    <div className="flex flex-col py-5 w-1/3 min-w-[300px] h-3/5 bg-primary_100 rounded-[16px]">
       <div className="flex justify-center gap-32 w-full">
         <button onClick={() => setModalOpen(false)}>창 닫기</button>
         <div className="flex bg-primary_50 rounded-[8px] py-2 px-3 gap-1">

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -8,12 +8,16 @@ const Toast = ({ setToast }: ToastProps) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       setToast(false);
-    }, 1500);
+    }, 2000);
 
-    return clearTimeout(timer);
+    return () => clearTimeout(timer);
   }, [setToast]);
 
-  return <div className="border-2">클립보드에 복사되었습니다</div>;
+  return (
+    <div className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 bg-black text-white px-4 py-2 rounded-lg shadow-lg text-sm animate-fade-in-out">
+      클립보드에 복사되었습니다
+    </div>
+  );
 };
 
 export default Toast;

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -1,0 +1,81 @@
+import { useNavigate } from 'react-router-dom';
+import RoomInfo from '../components/RoomInfo';
+import { useEffect, useState } from 'react';
+import { getRoomList, deleteRoom } from '../api/roomList.api';
+import { SimpleRoomInfo } from '../models/room.model';
+import InviteModal from '../components/Modal/InviteModal';
+import Modal from '../components/Modal/Modal';
+
+const mockData = [
+  {
+    roomId: 1,
+    roomName: '방1',
+    studentName: '학생 1',
+    subject: '과목1',
+    lessonDays: [
+      {
+        lessonDay: '월',
+      },
+      {
+        lessonDay: '수',
+      },
+    ],
+    student: {
+      studentId: 32,
+      gender: '남',
+      backgroundColor: '#000957',
+    },
+  },
+  {
+    roomId: 2,
+    roomName: '방2',
+    studentName: '학생 2',
+    subject: '과목2',
+    lessonDays: [
+      {
+        lessonDay: '금',
+      },
+      {
+        lessonDay: '토',
+      },
+      {
+        lessonDay: '일',
+      },
+    ],
+    student: {
+      studentId: 45,
+      gender: '여',
+      backgroundColor: '#ffffff',
+    },
+  },
+];
+
+const Invite = () => {
+  // const roleInfo = localStorage.getItem('roleInfo');
+  const roleInfo = 'student';
+  const navigate = useNavigate();
+  const [rooms, setRooms] = useState<SimpleRoomInfo[]>(mockData);
+  const [modalOpen, setModalOpen] = useState(true);
+  const InviteRoomId = 0;
+
+  useEffect(() => {
+    if (!modalOpen) navigate('/user/roomlist');
+  }, [modalOpen]);
+
+  return (
+    <div className="flex flex-col">
+      {modalOpen && (
+        <Modal onClose={() => setModalOpen(false)}>
+          <InviteModal setModalOpen={setModalOpen} id={InviteRoomId} />
+        </Modal>
+      )}
+      <div>
+        {rooms.map((room) => (
+          <RoomInfo roleInfo={roleInfo} room={room} handleDelete={() => {}} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Invite;

--- a/src/pages/Room/CreateRoom.tsx
+++ b/src/pages/Room/CreateRoom.tsx
@@ -11,7 +11,7 @@ const CreateRoom = () => {
   const handleCreate = async (roomInfo: RoomInfo) => {
     //const roomId = await postRoomInfo(roomInfo);
     const roomId = 3; // 임시
-    navigate('/user/roomlist/sharelink', { state: { roodId: roomId } });
+    navigate('/user/roomlist/sharecode', { state: { roomId: roomId } });
   };
 
   return (

--- a/src/pages/Room/RoomDetail.tsx
+++ b/src/pages/Room/RoomDetail.tsx
@@ -65,7 +65,7 @@ const RoomDetail = () => {
         isPermission={roomDetail.permission.deposit}
       />
       {/* role 보고 선생님이면 isPermission true */}
-      <DetailButton type="invite" isPermission={true} />
+      <DetailButton type="sharecode" isPermission={true} />
     </div>
   );
 };

--- a/src/pages/Room/ShareCode.tsx
+++ b/src/pages/Room/ShareCode.tsx
@@ -7,17 +7,13 @@ const ShareCode = () => {
   const location = useLocation();
   const navigation = useNavigate();
 
-  const [code, setCode] = useState('aaa');
+  const [code, setCode] = useState('');
   const [toast, setToast] = useState(false);
 
   useEffect(() => {
-    const roomId = location.state?.roomId;
-
-    /* const getCode = async () => {
-      const code = await getShareCode(roomId);
-      setCode(code);
-    };
-    getCode(); */
+    const roomId = location.state.roomId;
+    console.log(roomId);
+    setCode(`http://localhost:5173/user/roomlist/${roomId}/invite`);
   }, []);
 
   const handleCopy = async (code: string) => {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -28,6 +28,7 @@ import CreateCounseling from '../pages/Counseling/CreateCounseling';
 import CounselingDetail from '../pages/Counseling/CounselingDetail';
 import UserPolicy from '../pages/UserPolicy';
 import ShareCode from '../pages/Room/ShareCode';
+import Invite from '../pages/Invite';
 
 export const router = createBrowserRouter([
   {
@@ -76,6 +77,7 @@ export const router = createBrowserRouter([
               { path: 'diary/create', element: <CreateCounseling /> }, // 상담 일지 업로드
               { path: 'diary/:counselingId', element: <CounselingDetail /> }, // 상담 일지 상세
               { path: 'payment', element: <Payment /> },
+              { path: 'invite', element: <Invite /> },
             ],
           },
         ],


### PR DESCRIPTION
## 🔥 Issues

#19 

## ✅ What to do

- [x] 토스트 메시지 UI 수정
- [x] 초대 수락 모달 생성
- [x] 과외방 상세 -> 초대 링크 복사 기능 구현 

## 📄 Description

초대 수락 모달이 있는 페이지를 먼저 만들고 이 링크를 전달할 수 있도록 함.
페이지 링크: http://localhost:5173/user/roomlist/3/invite

수락 모달에서 '네"를 눌렀을 때,
프론트 -> 백 학생 Id, 방 Id(아직 확정x)를 넘겨주면 백에서 학생이 이미 들어가 있는지 확인 후 
백 -> 프론트로 아래 2가지 경우로 나눠서 알려줌

1. 이미 들어가 있는 경우
백에서 이미 들어가 있다고 프론트로 알려줌
프론트에서 "이미 초대되었습니다."라고 알림 (디자인 나오면 수정할 예정)

2. 안 들어간 경우
백에서 초대 수락한 학생과 선생님을 연결. 이후 프론트로 완료되었다고 알려줌
프론트에서 "초대 완료 되었습니다."라고 알림 (디자인 나오면 수정할 예정)

## 🤔 Considerations

아예 갈피를 못 잡고 있었는데 다형이의 도움이 컸다...

## 🛠️ Improvements to Make

디자인은 아직 안해서 이후 수정할 예정.
백에서 받아오는 부분도 추가해야 한다.
로그인 완료했을 때 이 경로로 다시 이동할 수 있게 하는 부분은 로그인 이후 구현할 예정.
만약에 방을 생성하고 코드 공유 페이지로 넘어갔는데 사용자가 이탈하는 경우는 어떻게 해야하나? 나중에 고민해봐야 할 듯.

## 👀 References

스크린샷 또는 참고사항
