### PR TITLE
[Fix] 라우터 구조, 헤더 개선 및 초대 페이지를 모달 전용으로 변경

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,61 +1,55 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { GoArrowLeft } from 'react-icons/go';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
+
+// 뒤로 가기 없는 페이지들
+const ROUTE_TITLES: { [key: string]: string } = {
+  '/user/mypage': '내 정보',
+  '/user/calendar': '달력',
+  '/user/roomlist': '과외방',
+};
+
+// 뒤로 가기 존재
+const HEADER_CONFIG = [
+  { path: '/materials', title: '강의 자료함' },
+  { path: '/homework', title: '주차별 숙제' },
+  { path: '/diary', title: '상담일지' },
+  { path: '/mypage/terms', title: '이용약관' },
+  { path: '/user/', title: '과외방 상세', startsWith: true },
+];
+
+// 회원가입 관련 페이지들
+const SIGNUP_PATHS = ['/signup', '/formbasic', '/formtel'];
 
 const Header = () => {
   const navigate = useNavigate();
   const location = useLocation().pathname;
 
-  const [left, setLeft] = useState(false);
-  const [title, setTitle] = useState('');
-  const [border, setBorder] = useState(true);
+  const { title, left } = useMemo(() => {
+    // 뒤로 가기 없음
+    if (ROUTE_TITLES[location]) {
+      return { title: ROUTE_TITLES[location], left: false };
+    }
 
-  useEffect(() => {
-    if (location.includes('/materials')) {
-      setTitle('강의 자료함');
-      setLeft(true);
-    } else if (location.includes('/homework')) {
-      setTitle('주차별 숙제');
-      setLeft(true);
-    } else if (location.includes('/diary')) {
-      setTitle('상담일지');
-      setLeft(true);
-    } else if (location.startsWith('/user/roomlist/')) {
-      setTitle('과외방 상세');
-      setLeft(true);
-    } else {
-      switch (location) {
-        case '/user/mypage':
-          setTitle('내 정보');
-          setLeft(false);
-          break;
-        case '/user/calendar':
-          setTitle('달력');
-          setLeft(false);
-          break;
-        case '/user/roomlist':
-          setTitle('과외방');
-          setLeft(false);
-          break;
-        case '/user/mypage/terms':
-          setTitle('이용약관');
-          setLeft(true);
-          break;
-        case '/signup':
-        case '/formbasic':
-        case '/formtel':
-          setLeft(true);
-          setBorder(false);
-          break;
-        default:
-          setTitle('');
-          break;
+    // 뒤로 가기 있음
+    for (const { path, title, startsWith } of HEADER_CONFIG) {
+      if (startsWith ? location.startsWith(path) : location.includes(path)) {
+        return { title, left: true };
       }
     }
+
+    // 회원가입 관련 페이지
+    if (SIGNUP_PATHS.includes(location)) {
+      return { title: '', left: true };
+    }
+
+    return { title: '', left: false };
   }, [location]);
 
   return (
-    <div className={`flex items-center py-2 px-1.5 ${border ? 'border-b-2' : 'border-0'} border-b-gray-100`}>
+    <div
+      className={`flex items-center py-2 px-1.5 ${SIGNUP_PATHS.includes(location) ? 'border-b-2' : 'border-0'} border-b-gray-100`}
+    >
       <div
         className={`flex w-11 h-11 justify-center items-center ${left ? 'cursor-pointer' : ''} `}
         onClick={() => {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -16,8 +16,13 @@ const NavBar = () => {
 
   useEffect(() => {
     const pathname = location.pathname.split('/');
-    setCurrentMenu(pathname[2]);
+    if (pathname[2] === 'calendar' || pathname[2] === 'mypage') {
+      setCurrentMenu(pathname[2]);
+    } else {
+      setCurrentMenu('roomlist');
+    }
   }, [location]);
+  console.log(currentMenu);
 
   const menus = [
     {

--- a/src/components/RoomInfo.tsx
+++ b/src/components/RoomInfo.tsx
@@ -48,7 +48,10 @@ const RoomInfo = ({ room, roleInfo, handleDelete }: RoomProps) => {
           <img className="w-9 h-9" src={student_girl} />
         )}
       </div>
-      <div className="flex flex-1 flex-col text-gray-900 cursor-pointer" onClick={() => navigate(`${room.roomId}`)}>
+      <div
+        className="flex flex-1 flex-col text-gray-900 cursor-pointer"
+        onClick={() => navigate(`/user/${room.roomId}`)}
+      >
         <h1 className="text-body1 font-bold leading-9">
           [{room.subject}] {room.roomName}
         </h1>

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -1,79 +1,25 @@
 import { useNavigate } from 'react-router-dom';
-import RoomInfo from '../components/RoomInfo';
 import { useEffect, useState } from 'react';
-import { getRoomList, deleteRoom } from '../api/roomList.api';
-import { SimpleRoomInfo } from '../models/room.model';
 import InviteModal from '../components/Modal/InviteModal';
 import Modal from '../components/Modal/Modal';
 
-const mockData = [
-  {
-    roomId: 1,
-    roomName: '방1',
-    studentName: '학생 1',
-    subject: '과목1',
-    lessonDays: [
-      {
-        lessonDay: '월',
-      },
-      {
-        lessonDay: '수',
-      },
-    ],
-    student: {
-      studentId: 32,
-      gender: '남',
-      backgroundColor: '#000957',
-    },
-  },
-  {
-    roomId: 2,
-    roomName: '방2',
-    studentName: '학생 2',
-    subject: '과목2',
-    lessonDays: [
-      {
-        lessonDay: '금',
-      },
-      {
-        lessonDay: '토',
-      },
-      {
-        lessonDay: '일',
-      },
-    ],
-    student: {
-      studentId: 45,
-      gender: '여',
-      backgroundColor: '#ffffff',
-    },
-  },
-];
-
 const Invite = () => {
-  // const roleInfo = localStorage.getItem('roleInfo');
-  const roleInfo = 'student';
+  let roleInfo = 'teacher';
   const navigate = useNavigate();
-  const [rooms, setRooms] = useState<SimpleRoomInfo[]>(mockData);
   const [modalOpen, setModalOpen] = useState(true);
   const InviteRoomId = 0;
 
   useEffect(() => {
-    if (!modalOpen) navigate('/user/roomlist');
+    if (!modalOpen) navigate(-1);
   }, [modalOpen]);
 
   return (
-    <div className="flex flex-col">
+    <div>
       {modalOpen && (
         <Modal onClose={() => setModalOpen(false)}>
           <InviteModal setModalOpen={setModalOpen} id={InviteRoomId} />
         </Modal>
       )}
-      <div>
-        {rooms.map((room) => (
-          <RoomInfo roleInfo={roleInfo} room={room} handleDelete={() => {}} />
-        ))}
-      </div>
     </div>
   );
 };

--- a/src/pages/Room/CreateRoom.tsx
+++ b/src/pages/Room/CreateRoom.tsx
@@ -11,7 +11,7 @@ const CreateRoom = () => {
   const handleCreate = async (roomInfo: RoomInfo) => {
     //const roomId = await postRoomInfo(roomInfo);
     const roomId = 3; // 임시
-    navigate('/user/roomlist/sharecode', { state: { roomId: roomId } });
+    navigate('/user/sharecode', { state: { roomId: roomId } });
   };
 
   return (

--- a/src/pages/Room/RoomList.tsx
+++ b/src/pages/Room/RoomList.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import RoomInfo from '../../components/RoomInfo';
 import { useEffect, useState } from 'react';
 import { getRoomList, deleteRoom } from '../../api/roomList.api';
@@ -81,11 +81,12 @@ const RoomList = () => {
       </div>
       <div className="flex justify-end py-8">
         {roleInfo === 'teacher' && (
-          <button onClick={() => navigate('createroom')} className="text-white px-4 bg-black">
+          <button onClick={() => navigate('/user/createroom')} className="text-white px-4 bg-black">
             + 과외방 개설
           </button>
         )}
       </div>
+      <Outlet />
     </div>
   );
 };

--- a/src/pages/Room/ShareCode.tsx
+++ b/src/pages/Room/ShareCode.tsx
@@ -13,7 +13,7 @@ const ShareCode = () => {
   useEffect(() => {
     const roomId = location.state.roomId;
     console.log(roomId);
-    setCode(`http://localhost:5173/user/roomlist/${roomId}/invite`);
+    setCode(`http://localhost:5173/user/roomlist/invite/${roomId}`);
   }, []);
 
   const handleCopy = async (code: string) => {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -57,35 +57,30 @@ export const router = createBrowserRouter([
     children: [
       {
         path: 'roomlist',
-        children: [
-          { index: true, element: <RoomList /> },
-          { path: 'createroom', element: <CreateRoom /> },
-          { path: 'sharecode', element: <ShareCode /> },
-          {
-            path: ':roomId',
-            children: [
-              { index: true, element: <RoomDetail /> },
-              { path: 'edit', element: <EditRoom /> },
-              { path: 'materials', element: <Materials /> }, // 강의 자료함
-              { path: 'materials/create', element: <CreateMaterials /> }, // 강의 자료 업로드
-              { path: 'materials/:materialId', element: <MaterialDetail /> }, // 강의 자료 상세
-              { path: 'homework', element: <Homework /> }, // 숙제방
-              { path: 'homework/create', element: <CreateHomework /> }, // 숙제 업로드
-              { path: 'homework/:homeworkId', element: <HomeworkDetail /> }, // 숙제 상세
-              { path: 'stats', element: <Statistics /> },
-              { path: 'diary', element: <CounselingDiary /> }, // 상담 일지
-              { path: 'diary/create', element: <CreateCounseling /> }, // 상담 일지 업로드
-              { path: 'diary/:counselingId', element: <CounselingDetail /> }, // 상담 일지 상세
-              { path: 'payment', element: <Payment /> },
-              { path: 'invite', element: <Invite /> },
-            ],
-          },
-        ],
+        element: <RoomList />,
+        children: [{ path: 'invite/:roomId', element: <Invite /> }],
       },
       {
-        path: 'calendar',
-        element: <Calendar />,
+        path: ':roomId',
+        children: [
+          { index: true, element: <RoomDetail /> },
+          { path: 'edit', element: <EditRoom /> },
+          { path: 'materials', element: <Materials /> }, // 강의 자료함
+          { path: 'materials/create', element: <CreateMaterials /> }, // 강의 자료 업로드
+          { path: 'materials/:materialId', element: <MaterialDetail /> }, // 강의 자료 상세
+          { path: 'homework', element: <Homework /> }, // 숙제방
+          { path: 'homework/create', element: <CreateHomework /> }, // 숙제 업로드
+          { path: 'homework/:homeworkId', element: <HomeworkDetail /> }, // 숙제 상세
+          { path: 'stats', element: <Statistics /> },
+          { path: 'diary', element: <CounselingDiary /> }, // 상담 일지
+          { path: 'diary/create', element: <CreateCounseling /> }, // 상담 일지 업로드
+          { path: 'diary/:counselingId', element: <CounselingDetail /> }, // 상담 일지 상세
+          { path: 'payment', element: <Payment /> },
+        ],
       },
+      { path: 'createroom', element: <CreateRoom /> },
+      { path: 'sharecode', element: <ShareCode /> },
+      { path: 'calendar', element: <Calendar /> },
       { path: 'mypage', element: <MyPage /> },
     ],
   },


### PR DESCRIPTION
## 🔥 Issues
#19 초대 페이지
#8 공통 컴포넌트

## ✅ What to do

- [x] 라우터 구조 개선
- [x] Invite 페이지 모달 전용으로 변경
- [x] 라우터 구조 변경에 따른 헤더, 네브바 수정  

## 📄 Description
### 라우터 구조 변경
* 기존 roomlist 하위에 포함되어 있던 방 상세 페이지(:roomId) 관련 라우트를 분리하여 roomlist와 동일한 depth를 갖도록 변경
* 초대 페이지(invite/:roomId)의 경로를 roomlist/:roomId/invite에서 **roomlist/invite/:roomId**로 수정
### 헤더 & 네비게이션 바 수정
* 라우터 구조 변경에 맞춰 헤더 및 네비게이션 바 관련 코드 수정

## 🤔 Considerations
### 초대 페이지 경로 변경
* 초대 페이지(기존 경로: `roomlist/:roomId/invite`)는 roomlist 위에 모달이 떠 있는 형태임
* 하지만 roomlist에서 초대 모달을 띄우기 위해 불필요한 방 목록을 다시 불러와야 했고, 모달이 닫히면 다시 roomlist로 이동하여 목록을 새로 불러와야 하는 비효율적인 구조였음
* **쿼리스트링(`?invite=true&roomId=3`)을 활용**하는 방식도 고려했으나,
  * roomlist 페이지가 방 목록과 초대 모달을 동시에 관리해야 하므로 **단일 책임 원칙(SRP)에 어긋남**
  * roomlist의 주요 역할은 **방 목록을 보여주는 것**이므로, 초대 모달을 직접 관리하는 것은 적절하지 않다고 판단
* 해결책으로, 초대 페이지를 **roomlist의 children**으로 이동
  * 이를 통해 `Outlet`을 활용하여 초대 모달을 분리된 페이지로 렌더링할 수 있도록 변경
  * 모달이 닫히면 기본적으로 roomlist로 돌아가도록 설정하여 자연스러운 흐름 유지
### 헤더 코드 최적화
* 기존에는 `if-else`와 `switch-case`를 사용하여 경로별 헤더 설정 → 중복 코드가 많음
* 특정 경로 패턴을 기준으로 **뒤로 가기 여부가 결정되는 페이지들을 그룹화**하여 객체/배열로 관리


## 🛠️ Improvements to Make
* 네비게이션 바는 캘린더와 마이페이지 아니면 그냥 다 과외방으로 선택되게 해놨는데... 나중에 예상치 못한 변수가 생길 수도 있겠다....

## 👀 References

스크린샷 또는 참고사항
