### PR TITLE
[Feat] 카카오 로그인 및 로그아웃, 토큰 재발급, 온보딩

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.9",
+        "jwt-decode": "^4.0.0",
         "postcss": "^8.4.49",
         "react": "^18.3.1",
         "react-datepicker": "^7.6.0",
@@ -6096,6 +6097,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.9",
+    "jwt-decode": "^4.0.0",
     "postcss": "^8.4.49",
     "react": "^18.3.1",
     "react-datepicker": "^7.6.0",

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,14 +1,45 @@
-import instance from './axios';
-import { UserInfo } from '../models/user.model';
+import { UserInfo, UserCode } from '../models/user.model';
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_BASE_URL;
 
 // 카카오 로그인 인가코드 보내기
-export const postAuthCode = async (code: string) => {
-  const res = await instance.post('/api/auth/kakao/signin', code);
-  return res.data;
+export const postAuthCode = async (code: UserCode) => {
+  const res = await axios.post(`${baseURL}/api/auth/kakao/login`, code, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  return res;
 };
 
-//회원가입 시 입력한 정보 보내기
+// 회원가입 시 입력한 정보 보내기
 export const postUserInfo = async (userInfo: UserInfo) => {
-  const res = await instance.post('/api/v1/user', userInfo);
-  return res.status;
+  const accessToken = localStorage.getItem('accessToken');
+  console.log(accessToken);
+
+  const res = await axios.post(`${baseURL}/api/auth/kakao/onboard`, userInfo, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return res;
+};
+
+// 로그아웃
+export const postLogout = async () => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  const res = await axios.post(
+    `${baseURL}/api/auth/kakao/logout`,
+    {},
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+  return res;
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -35,16 +35,14 @@ instance.interceptors.response.use(
     if (error.response.status === 401 && msg === '사용자의 로그인 검증을 실패했습니다.') {
       try {
         if (refreshToken) {
-          const res = await axios.post(
-            '/api/auth/kakao/token',
-            { refreshToken },
-            {
-              headers: {
-                'Content-Type': 'application/json',
-              },
+          const res = await axios.post('/api/auth/kakao/reissue', {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: refreshToken,
             },
-          );
-          localStorage.setItem('accessToken', res.headers.Authorization); // 백에서 header/body 중 어디로 주는 지 확인 후 수정
+          });
+          localStorage.setItem('accessToken', res.data.accessToken);
+          localStorage.setItem('refreshToken', res.data.refreshToken);
 
           // 새 토큰으로 헤더 업데이트 후 재요청
           error.config.headers.Authorization = `Bearer ${res.headers.Authorization}`;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -32,33 +32,30 @@ instance.interceptors.response.use(
     return response;
   },
   async (error) => {
-    // 토큰 만료 시
-    const msg = error.response.data.message; // 백엔드에서 토큰 만료됐다고 알려주는 msg
     const refreshToken = localStorage.getItem('refreshToken');
+
+    // 메세지에 상관없이 코드가 401이면 모두 토큰 재발급
     if (error.response.status === 401) {
       try {
-        if (refreshToken) {
-          const res = await axios.post(
-            '/api/auth/kakao/reissue',
-            {},
-            {
-              headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${refreshToken}`,
-              },
-            },
-          );
-          if (res.status == 200) {
-            localStorage.setItem('accessToken', res.data.accessToken);
-            localStorage.setItem('refreshToken', res.data.refreshToken);
+        const res = await axios.get('/api/auth/kakao/reissue', {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${refreshToken}`,
+          },
+        });
+        if (res.status == 200) {
+          const { accessToken, refreshToken } = res.data.data;
+          localStorage.setItem('accessToken', accessToken);
+          localStorage.setItem('refreshToken', refreshToken);
 
-            const decoded = jwtDecode(res.data.accessToken) as JwtPayload & { role: string };
-            localStorage.setItem('roleInfo', decoded.role);
-          }
-          // 새 토큰으로 헤더 업데이트 후 재요청
-          error.config.headers.Authorization = `Bearer ${res.headers.Authorization}`;
-          return axios(error.config);
+          const decoded = jwtDecode(accessToken) as JwtPayload & { role: string };
+          localStorage.setItem('roleInfo', decoded.role);
+          console.log(res.data.message);
         }
+
+        // 새 토큰으로 헤더 업데이트 후 재요청
+        error.config.headers.Authorization = `Bearer ${res.data.data.accessToken}`;
+        return axios(error.config);
       } catch (refreshErr) {
         console.log('Token 갱신 실패: ', refreshErr);
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
+import { jwtDecode, JwtPayload } from 'jwt-decode';
+
 const baseURL = import.meta.env.VITE_BASE_URL;
 
 const instance: AxiosInstance = axios.create({
@@ -25,6 +27,7 @@ instance.interceptors.request.use(
 );
 
 instance.interceptors.response.use(
+  // status가 2xx-> 그럼 다른 코드에서 굳이 코드가 200인지 확인 안해도 되나?
   (response) => {
     return response;
   },
@@ -32,18 +35,26 @@ instance.interceptors.response.use(
     // 토큰 만료 시
     const msg = error.response.data.message; // 백엔드에서 토큰 만료됐다고 알려주는 msg
     const refreshToken = localStorage.getItem('refreshToken');
-    if (error.response.status === 401 && msg === '사용자의 로그인 검증을 실패했습니다.') {
+    if (error.response.status === 401) {
       try {
         if (refreshToken) {
-          const res = await axios.post('/api/auth/kakao/reissue', {
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: refreshToken,
+          const res = await axios.post(
+            '/api/auth/kakao/reissue',
+            {},
+            {
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${refreshToken}`,
+              },
             },
-          });
-          localStorage.setItem('accessToken', res.data.accessToken);
-          localStorage.setItem('refreshToken', res.data.refreshToken);
+          );
+          if (res.status == 200) {
+            localStorage.setItem('accessToken', res.data.accessToken);
+            localStorage.setItem('refreshToken', res.data.refreshToken);
 
+            const decoded = jwtDecode(res.data.accessToken) as JwtPayload & { role: string };
+            localStorage.setItem('roleInfo', decoded.role);
+          }
           // 새 토큰으로 헤더 업데이트 후 재요청
           error.config.headers.Authorization = `Bearer ${res.headers.Authorization}`;
           return axios(error.config);
@@ -54,6 +65,7 @@ instance.interceptors.response.use(
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         localStorage.removeItem('roleInfo');
+
         window.location.href = '/login';
       }
     }

--- a/src/components/Calendar/CalendarInfo.tsx
+++ b/src/components/Calendar/CalendarInfo.tsx
@@ -19,8 +19,8 @@ const CalendarInfo = ({ clickDate, roleInfo }: CalendarProps) => {
       <div className="flex flex-col gap-2">
         {clickDate.roomname && <CalendarDeposit roomname={clickDate.roomname} />}
         {clickDate.subjectAndRoom && <CalendarLesson subjectAndRoom={clickDate.subjectAndRoom} />}
-        {!clickDate.roomname && !clickDate.subjectAndRoom && roleInfo === 'teacher' && <CalendarNolesson />}
-        {!clickDate.roomname && !clickDate.subjectAndRoom && (roleInfo === 'parent' || roleInfo === 'student') && (
+        {!clickDate.roomname && !clickDate.subjectAndRoom && roleInfo === 'TEACHER' && <CalendarNolesson />}
+        {!clickDate.roomname && !clickDate.subjectAndRoom && (roleInfo === 'PARENT' || roleInfo === 'STUDENT') && (
           <CalendarNolessonStudent />
         )}
       </div>

--- a/src/components/KakaoOauth.tsx
+++ b/src/components/KakaoOauth.tsx
@@ -1,41 +1,57 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { postAuthCode } from '../api/auth.api';
+import { UserCode } from '../models/user.model';
 
 const KakaoOauth = () => {
   const navigate = useNavigate();
   const [isProcessed, setIsProcessed] = useState(false);
-  const code = new URL(window.location.href).searchParams.get('code');
-  console.log(code);
+  const [code, setCode] = useState<UserCode | null>(null);
+
+  useEffect(() => {
+    const authCode = new URL(window.location.href).searchParams.get('code');
+    if (authCode) {
+      setCode({
+        provider: 'KAKAO',
+        redirectUrl: 'http://localhost:5173/api/auth/kakao/callback',
+        code: authCode,
+      });
+    } else {
+      console.error('No authorization code found in URL.');
+    }
+  }, []);
 
   const handleAuth = async () => {
     if (!code) return;
-
-    const { accessToken, refreshToken, status } = await postAuthCode(code);
-
-    if (accessToken) {
-      localStorage.setItem('accesstoken', accessToken);
-    }
-    if (refreshToken) {
+    try {
+      const res = await postAuthCode(code);
+      console.log('API 응답:', res.data);
+      const accessToken = res.data.data.accessToken;
+      const refreshToken = res.data.data.refreshToken;
+      const isOnboarding = res.data.data.isOnboarding;
+      localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
-    }
 
-    if (status === 'existing') {
-      // 이미 회원인 경우 로그인 완료 -> 메인페이지로 이동
-      // navigate('/');
-    } else if (status === 'new') {
-      // 신규 회원인 경우 -> 회원가입 페이지로 이동
-      // navigate('/signup');
+      if (!isOnboarding) {
+        navigate('/user/roomlist');
+      } else {
+        navigate('/signup');
+      }
+
+      setIsProcessed(true);
+    } catch (error) {
+      console.error('Authorization failed:', error);
+    } finally {
+      setIsProcessed(true);
     }
-    setIsProcessed(true);
   };
 
   useEffect(() => {
-    if (isProcessed) return; // 이미 처리한 경우 return
+    if (isProcessed || !code) return; // 이미 처리했거나 code가 없는 경우 return
     handleAuth();
-  }, [isProcessed]);
+  }, [isProcessed, code]);
 
-  return <div>회원인지 확인 중입니다.</div>;
+  return <div>회원 확인 중입니다. 잠시만 기다려주세요...</div>;
 };
 
 export default KakaoOauth;

--- a/src/components/KakaoOauth.tsx
+++ b/src/components/KakaoOauth.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { postAuthCode } from '../api/auth.api';
 import { UserCode } from '../models/user.model';
+import { jwtDecode, JwtPayload } from 'jwt-decode';
 
 const KakaoOauth = () => {
   const navigate = useNavigate();
@@ -17,7 +18,7 @@ const KakaoOauth = () => {
         code: authCode,
       });
     } else {
-      console.error('No authorization code found in URL.');
+      console.error('인가코드가 존재하지 않습니다.');
     }
   }, []);
 
@@ -25,24 +26,29 @@ const KakaoOauth = () => {
     if (!code) return;
     try {
       const res = await postAuthCode(code);
-      console.log('API 응답:', res.data);
-      const accessToken = res.data.data.accessToken;
-      const refreshToken = res.data.data.refreshToken;
-      const isOnboarding = res.data.data.isOnboarding;
-      localStorage.setItem('accessToken', accessToken);
-      localStorage.setItem('refreshToken', refreshToken);
+      if (res.status == 200) {
+        const { accessToken, refreshToken, isOnboarding } = res.data.data;
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
 
-      if (!isOnboarding) {
-        navigate('/user/roomlist');
-      } else {
-        navigate('/signup');
+        const decoded = jwtDecode(accessToken) as JwtPayload & { role: string };
+        localStorage.setItem('roleInfo', decoded.role);
+        console.log(res.data.message);
+
+        if (!isOnboarding) {
+          navigate('/user/roomlist');
+        } else {
+          navigate('/signup');
+        }
+
+        setIsProcessed(true);
       }
-
-      setIsProcessed(true);
-    } catch (error) {
-      console.error('Authorization failed:', error);
-    } finally {
-      setIsProcessed(true);
+    } catch (err: any) {
+      if (err.response.status === 400 || err.response.status === 500) {
+        console.log('오류:', err.response.data.error);
+      } else {
+        console.log(err);
+      }
     }
   };
 

--- a/src/components/Modal/LogoutModal.tsx
+++ b/src/components/Modal/LogoutModal.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { postLogout } from '../../api/auth.api';
+import { useNavigate } from 'react-router-dom';
 
 interface LogoutModalProps {
   setModalOpen: (value: boolean) => void;
@@ -17,6 +19,7 @@ export const MODAL_TYPE = {
 } as const;
 
 const LogoutModal = ({ setModalOpen, type }: LogoutModalProps) => {
+  const navigate = useNavigate();
   const DEFAULT_TYPE = {
     text: '',
     buttonText: '',
@@ -42,9 +45,18 @@ const LogoutModal = ({ setModalOpen, type }: LogoutModalProps) => {
     }
   }, []);
 
-  const handleLogOut = () => {
+  const handleLogOut = async () => {
     // 로그아웃 로직
-    console.log('로그아웃');
+    try {
+      const res = await postLogout();
+      console.log(res);
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      navigate('/');
+    }
   };
 
   const handleQuit = () => {

--- a/src/components/Modal/LogoutModal.tsx
+++ b/src/components/Modal/LogoutModal.tsx
@@ -49,13 +49,19 @@ const LogoutModal = ({ setModalOpen, type }: LogoutModalProps) => {
     // 로그아웃 로직
     try {
       const res = await postLogout();
-      console.log(res);
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-    } catch (e) {
-      console.error(e);
-    } finally {
-      navigate('/');
+      if (res.status == 200) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('roleInfo');
+        console.log(res.data.message);
+        navigate('/');
+      }
+    } catch (err: any) {
+      if (err.response.status === 401 || err.response.status === 404) {
+        console.log('오류:', err.response.data.error);
+      } else {
+        console.log(err);
+      }
     }
   };
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ interface ProtectedRouteProps {
 }
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const isAuthenticated = true;
+  const isAuthenticated = !!localStorage.getItem('accessToken');
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" />;
 };
 

--- a/src/components/RoomInfo.tsx
+++ b/src/components/RoomInfo.tsx
@@ -21,8 +21,8 @@ const RoomInfo = ({ room, roleInfo, handleDelete }: RoomProps) => {
   const navigate = useNavigate();
 
   const handleEdit = () => {
-    if (roleInfo === 'student' || 'parent') setStudentEditOpen(true);
-    else if (roleInfo === 'teacher') navigate(`${room.roomId}/edit`);
+    if (roleInfo === 'STUDENT' || 'PARENT') setStudentEditOpen(true);
+    else if (roleInfo === 'TEACHER') navigate(`${room.roomId}/edit`);
   };
 
   return (

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,6 +1,13 @@
 export interface UserInfo {
-  role: string;
+  role: '선생님' | '학생' | '부모' | '';
   username: string;
   phoneNumber: string;
-  gender: string;
+  gender: '남' | '여' | '';
+  backgroundColor: string;
+}
+
+export interface UserCode {
+  provider: 'KAKAO';
+  redirectUrl: 'http://localhost:5173/api/auth/kakao/callback';
+  code: string;
 }

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,8 +1,8 @@
 export interface UserInfo {
-  role: '선생님' | '학생' | '부모' | '';
+  role: '선생님' | '학생' | '학부모' | '';
   username: string;
   phoneNumber: string;
-  gender: '남' | '여' | '';
+  gender: '남성' | '여성' | '';
   backgroundColor: string;
 }
 

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -33,7 +33,6 @@ const mockData = [
 ];
 
 const Calendar = () => {
-  const roleInfo = 'student';
   const [date, setDate] = useState(new Date());
   const [clickDate, setClickDate] = useState<Clicked>({
     date: date,
@@ -42,6 +41,12 @@ const Calendar = () => {
     roomname: hasDeposit(date, mockData),
     subjectAndRoom: hasLesson(date, mockData),
   });
+  const [roleInfo, setRoleInfo] = useState('');
+
+  useEffect(() => {
+    const role = localStorage.getItem('roleInfo');
+    setRoleInfo(role || '');
+  }, []);
 
   /* useEffect(() => {
     const fetchCalendar = async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,7 @@
-import { useNavigate } from 'react-router-dom';
 import KakaoLoginButton from '../components/KakaoLoginButton';
 import logingate from '../assets/images/logingate.png';
 
 const Login = () => {
-  const navigate = useNavigate();
   return (
     <div className="flex flex-col min-h-screen">
       <div className="flex flex-col items-start px-4 py-6 text-heading6 font-bold leading-10 text-gray-900">

--- a/src/pages/Room/EditRoom.tsx
+++ b/src/pages/Room/EditRoom.tsx
@@ -42,8 +42,9 @@ const EditRoom = () => {
 
   useEffect(() => {
     const fetchCurrentRoom = async () => {
-      const currentRoom = await getCurrentRoomInfo(paramsId);
-      setCurrentRoom(currentRoom);
+      const res = await getCurrentRoomInfo(paramsId);
+      console.log(res);
+      //setCurrentRoom(res.data);
     };
     fetchCurrentRoom();
   }, []);

--- a/src/pages/Room/RoomList.tsx
+++ b/src/pages/Room/RoomList.tsx
@@ -20,7 +20,7 @@ const mockData = [
     ],
     student: {
       studentId: 32,
-      gender: '남',
+      gender: '남성',
       backgroundColor: '#000957',
     },
   },
@@ -42,17 +42,16 @@ const mockData = [
     ],
     student: {
       studentId: 45,
-      gender: '여',
+      gender: '여성',
       backgroundColor: '#ffffff',
     },
   },
 ];
 
 const RoomList = () => {
-  // const roleInfo = localStorage.getItem('roleInfo');
-  const roleInfo = 'teacher';
   const navigate = useNavigate();
   const [rooms, setRooms] = useState<SimpleRoomInfo[]>(mockData);
+  const [roleInfo, setRoleInfo] = useState('');
 
   const fetchRooms = async () => {
     //const rooms = await getRoomList();
@@ -60,6 +59,8 @@ const RoomList = () => {
   };
 
   useEffect(() => {
+    const role = localStorage.getItem('roleInfo');
+    setRoleInfo(role || '');
     fetchRooms();
   }, []);
 
@@ -80,7 +81,7 @@ const RoomList = () => {
         ))}
       </div>
       <div className="flex justify-end py-8">
-        {roleInfo === 'teacher' && (
+        {roleInfo === 'TEACHER' && (
           <button onClick={() => navigate('/user/createroom')} className="text-white px-4 bg-black">
             + 과외방 개설
           </button>

--- a/src/pages/Room/RoomList.tsx
+++ b/src/pages/Room/RoomList.tsx
@@ -55,7 +55,7 @@ const RoomList = () => {
   const [rooms, setRooms] = useState<SimpleRoomInfo[]>(mockData);
 
   const fetchRooms = async () => {
-    const rooms = await getRoomList();
+    //const rooms = await getRoomList();
     setRooms(rooms);
   };
 
@@ -76,7 +76,7 @@ const RoomList = () => {
     <div className="flex flex-col">
       <div>
         {rooms.map((room) => (
-          <RoomInfo roleInfo={roleInfo} room={room} handleDelete={handleDelete} />
+          <RoomInfo key={room.roomId} roleInfo={roleInfo} room={room} handleDelete={handleDelete} />
         ))}
       </div>
       <div className="flex justify-end py-8">

--- a/src/pages/Signup/FormBasic.tsx
+++ b/src/pages/Signup/FormBasic.tsx
@@ -1,25 +1,33 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Header from '../../components/Header';
 
 const FormBasic = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const [genders, setGenders] = useState([
     {
       id: 0,
-      type: '남성',
+      type: '남',
       isClicked: false,
     },
     {
       id: 1,
-      type: '여성',
+      type: '여',
       isClicked: false,
     },
   ]);
+
+  const [role, setRole] = useState([]);
   const [basicInput, setBasicInput] = useState({
     username: '',
     gender: '',
   });
+
+  useEffect(() => {
+    setRole(location.state?.role);
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setBasicInput({ ...basicInput, [e.target.id]: e.target.value });
@@ -28,6 +36,7 @@ const FormBasic = () => {
   const handleStart = async () => {
     navigate('/formtel', {
       state: {
+        role: role,
         username: basicInput.username,
         gender: basicInput.gender,
       },

--- a/src/pages/Signup/FormBasic.tsx
+++ b/src/pages/Signup/FormBasic.tsx
@@ -9,12 +9,12 @@ const FormBasic = () => {
   const [genders, setGenders] = useState([
     {
       id: 0,
-      type: '남',
+      type: '남성',
       isClicked: false,
     },
     {
       id: 1,
-      type: '여',
+      type: '여성',
       isClicked: false,
     },
   ]);

--- a/src/pages/Signup/FormTel.tsx
+++ b/src/pages/Signup/FormTel.tsx
@@ -13,14 +13,15 @@ const FormTel = () => {
     username: '',
     phoneNumber: '',
     gender: '',
+    backgroundColor: '#C15A5A',
   });
 
   useEffect(() => {
-    const roleInfo = localStorage.getItem('roleInfo');
+    const role = location.state?.role;
     const username = location.state?.username;
     const gender = location.state?.gender;
 
-    if (roleInfo) setUserInput({ ...userInput, role: roleInfo, username: username, gender: gender });
+    if (role) setUserInput({ ...userInput, role: role, username: username, gender: gender });
   }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -29,9 +30,19 @@ const FormTel = () => {
   console.log(userInput);
 
   const handleStart = async () => {
-    // const status = await postUserInfo(userInput);
-    // console.log(status);
-    navigate('/signupcomplete');
+    try {
+      const res = await postUserInfo(userInput);
+      console.log('Authorization successful:', res.data);
+
+      const accessToken = res.data.data.accessToken;
+      const refreshToken = res.data.data.refreshToken;
+      localStorage.setItem('accesstoken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+    } catch (error) {
+      console.error('Authorization failed:', error);
+    } finally {
+      // navigate('/signupcomplete');
+    }
   };
 
   return (

--- a/src/pages/Signup/FormTel.tsx
+++ b/src/pages/Signup/FormTel.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { postUserInfo } from '../../api/auth.api';
 import Header from '../../components/Header';
 import { UserInfo } from '../../models/user.model';
+import { jwtDecode, JwtPayload } from 'jwt-decode';
 
 const FormTel = () => {
   const navigate = useNavigate();
@@ -32,16 +33,25 @@ const FormTel = () => {
   const handleStart = async () => {
     try {
       const res = await postUserInfo(userInput);
-      console.log('Authorization successful:', res.data);
+      if (res.status == 200) {
+        const accessToken = res.data.data.accessToken;
+        const refreshToken = res.data.data.refreshToken;
 
-      const accessToken = res.data.data.accessToken;
-      const refreshToken = res.data.data.refreshToken;
-      localStorage.setItem('accesstoken', accessToken);
-      localStorage.setItem('refreshToken', refreshToken);
-    } catch (error) {
-      console.error('Authorization failed:', error);
+        localStorage.setItem('accesstoken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+
+        const decoded = jwtDecode(accessToken) as JwtPayload & { role: string };
+        localStorage.setItem('roleInfo', decoded.role);
+        console.log(res.data.message);
+      }
+    } catch (err: any) {
+      if (err.response.status === 400 || err.response.status === 401 || err.response.status === 404) {
+        console.log('오류:', err.response.data.error);
+      } else {
+        console.log(err);
+      }
     } finally {
-      // navigate('/signupcomplete');
+      navigate('/signupcomplete');
     }
   };
 

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import Header from '../../components/Header';
 import RoleSelectionButton from '../../components/RoleSelectionButton';
 import { RoleList } from '../../utils/RoleList';

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -1,7 +1,5 @@
-import instance from '../../api/axios';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { postUserInfo } from '../../api/auth.api';
 
 import Header from '../../components/Header';
 import RoleSelectionButton from '../../components/RoleSelectionButton';
@@ -14,8 +12,11 @@ const Signup = () => {
     if (!role) return;
 
     console.log(`선택한 역할: ${role}`);
-    localStorage.setItem('roleInfo', role);
-    navigate('/formbasic');
+    navigate('/formbasic', {
+      state: {
+        role: role,
+      },
+    });
   };
 
   return (
@@ -30,8 +31,8 @@ const Signup = () => {
           <RoleSelectionButton
             key={item.id}
             role={item}
-            onSelect={() => setRole(item.role)}
-            isSelected={role === item.role}
+            onSelect={() => setRole(item.title)}
+            isSelected={role === item.title}
           />
         ))}
       </div>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -39,7 +39,7 @@ export const router = createBrowserRouter([
     path: 'login',
     element: <Login />,
   },
-  { path: 'oauth', element: <KakaoOauth /> },
+  { path: 'api/auth/kakao/callback', element: <KakaoOauth /> },
   {
     path: 'signup',
     element: <Signup />,

--- a/src/utils/RoleList.ts
+++ b/src/utils/RoleList.ts
@@ -27,7 +27,7 @@ export const RoleList: Role[] = [
   },
   {
     id: 2,
-    title: '학부모',
+    title: '부모',
     description: '선생님과 소통하고 입금해요.',
     src: mom,
     role: 'parent',

--- a/src/utils/RoleList.ts
+++ b/src/utils/RoleList.ts
@@ -7,7 +7,7 @@ export interface Role {
   title: string;
   description: string;
   src: string;
-  role: 'student' | 'teacher' | 'parent';
+  role: 'STUDENT' | 'TEACHER' | 'PARENT';
 }
 
 export const RoleList: Role[] = [
@@ -16,20 +16,20 @@ export const RoleList: Role[] = [
     title: '학생',
     description: '선생님과 소통하고 과제를 제출해요.',
     src: boy,
-    role: 'student',
+    role: 'STUDENT',
   },
   {
     id: 1,
     title: '선생님',
     description: '학생, 학부모와 소통하고 수업해요.',
     src: teacher,
-    role: 'teacher',
+    role: 'TEACHER',
   },
   {
     id: 2,
     title: '부모',
     description: '선생님과 소통하고 입금해요.',
     src: mom,
-    role: 'parent',
+    role: 'PARENT',
   },
 ];


### PR DESCRIPTION
## 🔥 Issues

#9 

## ✅ What to do

- [x] 카카오 로그인
- [x] 카카오 로그아웃
- [x] 토큰 재발급
- [x] 온보딩

## 📄 Description

상세 설명

## 🤔 Considerations
1. 카카오 로그인
redirect URI에 접근이 안돼서 front 주소를 추가하였다.
나중에 배포하면 바꿔야 하나? 잘 모르겠다.
CORS에러는 백에서 해결.

2. 토큰에 role이 있어서 decode를 한 후 role만 가져와서 localStorage에 저장하였다.
role이 decode 기본 옵션이 아니라 무조건 있다는 전제 하에 & { role: string }을 붙였다.
role이 없는 경우는 "ONBOARDING"으로 나온다.

3. 토큰 재발급
확인을 못해서 잘 되는 지 모르겠다. 우선 API대로 코드는 짰는데 나중에 확인해보면 좋을듯.
interceptor에서 response는 status가 2xx인 걸 모두 처리하는데 그럼 나중에 코드짤 때 200인지 확인 안해도 되나?
그리고 백에서 메세지에 상관없이 코드가 401이면 모두 토큰 재발급하라고해서 msg 부분은 뺐다.
토큰 다시 받는 부분은 로그인 할 때랑 똑같이 구현해서 아마 작동할 것 같지만 나중에 확인해봐야 한다.

## 🛠️ Improvements to Make

- axios.ts 아마 개선해야 할 듯.
- 회원 탈퇴는 아직 백에서 구현 안돼서 기다리는 중.

## 👀 References

- jwt-decode
https://github.com/auth0/jwt-decode
