### PR TITLE
[Fix] date-picker 모달 수정

### DIFF
--- a/src/components/Calendar/DateHandler.tsx
+++ b/src/components/Calendar/DateHandler.tsx
@@ -21,7 +21,7 @@ const DateHandler = ({ date, setDate }: DateProps) => {
         <MdKeyboardArrowLeft size={24} />
       </button>
       <div className="px-2 text-xl font-medium text-gray-900">
-        {date.getFullYear()}.{date.getMonth() < 10 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}
+        {date.getFullYear()}.{date.getMonth() < 9 ? '0' + (date.getMonth() + 1) : date.getMonth() + 1}
       </div>
       <button className="p-2" onClick={handleRight}>
         <MdKeyboardArrowRight size={24} />

--- a/src/components/RoomDetail/DatePicker.tsx
+++ b/src/components/RoomDetail/DatePicker.tsx
@@ -37,7 +37,7 @@ const DatePicker = ({ setValue, onClose }: DatePickerProps) => {
   };
 
   return (
-    <div className="bg-white rounded-2xl w-[90%] h-[58%] px-4 flex-col justify-between flex pb-4">
+    <div className="bg-white rounded-2xl w-max-[90%] h-min-[58%] px-4 flex-col justify-between flex pb-4">
       <div>
         <DateHandler date={date} setDate={setDate} />
       </div>

--- a/src/utils/CalendarUtils.ts
+++ b/src/utils/CalendarUtils.ts
@@ -45,10 +45,12 @@ export const groupDatesByWeek = (firstDay: Date, lastDay: Date) => {
   }
 
   // 말일 이후 공백 추가
-  while (currentWeek.length < 7) {
-    currentWeek.push(null);
+  if (currentWeek.length > 0 && currentWeek.some((day) => day !== null)) {
+    while (currentWeek.length < 7) {
+      currentWeek.push(null);
+    }
+    weeks.push(currentWeek);
   }
 
-  weeks.push(currentWeek);
   return weeks;
 };


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] date-picker 모달 수정

## 📄 Description
* 10월이 010으로 뜨는 문제 해결
* 5주인 달에 모달에서 버튼이 벗어나는 문제 해결
* 달의 마지막 날의 요일이 일요일이면 공백인 줄이 하나 더 생기는 문제 해결

## 🤔 Considerations
* 10월이 '010'으로 표시되는 문제: 
  * getMonth()는 0부터 시작하기 때문에, 10보다 작은 경우에 0을 붙이는 로직이 10월(9)까지 적용됨.
  * 9 이하일 때만 0을 붙이도록 수정.
* 5주인 달에 모달에서 버튼이 벗어나는 문제:
  * h-[58%]을 h-min-[58%]로 수정해, 5주일 때 모달의 높이도 같이 늘어나도록 개선.
* 달의 마지막 날이 일요일일 때 공백인 줄이 추가되는 문제:
  * 기존에는 currentWeek의 길이가 7보다 작으면 공백을 추가해서, 마지막 날이 일요일일 때 불필요하게 빈 줄이 추가됨.
  * currentWeek가 길이가 0보다 크고, null이 아닌 값이 있을 때만 공백을 추가하도록 수정했음.

## 🛠️ Improvements to Make

개선할 사항

## 👀 References
<img width="341" alt="image" src="https://github.com/user-attachments/assets/5ef6257f-a99e-4674-a15e-571cb3113ca7" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/612763d6-c1d3-4e65-99f4-74abdd76db83" />

