### PR TITLE
[Refactor] 강의 자료함 코드 구조 개선

### DIFF
--- a/src/api/materials.api.ts
+++ b/src/api/materials.api.ts
@@ -19,8 +19,12 @@ export const uploadLectureFile = async (roomId: string, payload: SimpleLectureFi
 
 // 강의 자료 목록 조회
 export const getLectureFileBoxes = async (roomId: string) => {
-  const response = await instance.get(`/api/v1/rooms/${roomId}/lectureFileBoxes`);
-  return response.data;
+  try {
+    const response = await instance.get(`/api/v1/rooms/${roomId}/lectureFileBoxes`);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 // 강의 자료 상세 조회

--- a/src/api/materials.api.ts
+++ b/src/api/materials.api.ts
@@ -29,10 +29,14 @@ export const getLectureFileBoxes = async (roomId: string) => {
 
 // 강의 자료 상세 조회
 export const getLectureFileDeatil = async (roomId: string, lectureFileBoxId: string) => {
-  const response = await instance.get(
-    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
-  );
-  return response.data;
+  try {
+    const response = await instance.get(
+      `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 // 강의 자료 삭제

--- a/src/api/materials.api.ts
+++ b/src/api/materials.api.ts
@@ -1,12 +1,20 @@
 import instance from '../api/axios';
-import { LectureFileBoxDetail, SimpleLectureFileBox, UpdateLectureFileBox } from '../models/materials.model';
+import {
+  LectureFileBoxDetail,
+  SimpleLectureFileBox,
+  UpdateLectureFileBox,
+} from '../models/materials.model';
 import { createMaterialFormData, createUpdateMaterialFormData } from '../utils/formDataUtils';
 
 // 강의 자료함 생성
 export const uploadLectureFile = async (roomId: string, payload: SimpleLectureFileBox) => {
-  const formData = createMaterialFormData(payload);
-  const response = await instance.post(`/api/v1/rooms/${roomId}/lectureFileBoxes`, formData);
-  return response.data;
+  try {
+    const formData = createMaterialFormData(payload);
+    const response = await instance.post(`/api/v1/rooms/${roomId}/lectureFileBoxes`, formData);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 // 강의 자료 목록 조회
@@ -17,25 +25,38 @@ export const getLectureFileBoxes = async (roomId: string) => {
 
 // 강의 자료 상세 조회
 export const getLectureFileDeatil = async (roomId: string, lectureFileBoxId: string) => {
-  const response = await instance.get(`/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`);
+  const response = await instance.get(
+    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
+  );
   return response.data;
 };
 
 // 강의 자료 삭제
 export const deleteLectureFile = async (roomId: string, lectureFileBoxId: string) => {
-  const response = await instance.delete(`/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`);
+  const response = await instance.delete(
+    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
+  );
   return response.data;
 };
 
 // 강의 자료 수정
-export const patchLectureFile = async (roomId: string, lectureFileBoxId: string, payload: UpdateLectureFileBox) => {
+export const patchLectureFile = async (
+  roomId: string,
+  lectureFileBoxId: string,
+  payload: UpdateLectureFileBox,
+) => {
   const formData = createUpdateMaterialFormData(payload);
-  const response = await instance.patch(`/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`, formData);
+  const response = await instance.patch(
+    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
+    formData,
+  );
   return response.data;
 };
 
 // 강의 자료 파일 전체 다운로드
 export const getAllLectureFile = async (roomId: string, lectureFileBoxId: number) => {
-  const response = await instance.get(`/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}/download`);
+  const response = await instance.get(
+    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}/download`,
+  );
   return response.data;
 };

--- a/src/api/materials.api.ts
+++ b/src/api/materials.api.ts
@@ -53,18 +53,26 @@ export const patchLectureFile = async (
   lectureFileBoxId: string,
   payload: UpdateLectureFileBox,
 ) => {
-  const formData = createUpdateMaterialFormData(payload);
-  const response = await instance.patch(
-    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
-    formData,
-  );
-  return response.data;
+  try {
+    const formData = createUpdateMaterialFormData(payload);
+    const response = await instance.patch(
+      `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}`,
+      formData,
+    );
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
 };
 
 // 강의 자료 파일 전체 다운로드
 export const getAllLectureFile = async (roomId: string, lectureFileBoxId: number) => {
-  const response = await instance.get(
-    `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}/download`,
-  );
-  return response.data;
+  try {
+    const response = await instance.get(
+      `/api/v1/rooms/${roomId}/lectureFileBoxes/${lectureFileBoxId}/download`,
+    );
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
 };

--- a/src/components/Material/FileDetail.tsx
+++ b/src/components/Material/FileDetail.tsx
@@ -1,9 +1,7 @@
 import { FaRegFileAlt } from 'react-icons/fa';
 import vector_gray from '../../assets/images/vector_gray.png';
 import { RiDownloadLine } from 'react-icons/ri';
-import { getAllLectureFile } from '../../api/materials.api';
 import { downloadFile } from '../../utils/DownloadFiles';
-import { useParams } from 'react-router-dom';
 import { FiTrash2 } from 'react-icons/fi';
 
 interface FileDetailProps {

--- a/src/components/Material/FileList.tsx
+++ b/src/components/Material/FileList.tsx
@@ -1,13 +1,18 @@
 import { HomeworkFile } from '../../models/homework.model';
+import { LectureFile } from '../../models/materials.model';
 import FileDetail from './FileDetail';
 
-interface FileListProps {
-  files: HomeworkFile[] | undefined;
-  onDelete?: (file: HomeworkFile, index: number) => void;
-  type?: boolean; // false면 삭제 버튼이 있어야함 -> fileURL 넘기지 말것.
+interface FileListProps<T> {
+  files: T[] | undefined;
+  onDelete?: (file: T, index: number) => void;
+  type?: boolean;
 }
 
-const FileList = ({ files, onDelete, type }: FileListProps) => {
+const FileList = <T extends HomeworkFile | LectureFile>({
+  files,
+  onDelete,
+  type,
+}: FileListProps<T>) => {
   return (
     <div className="mt-2 mb-4 gap-2 flex flex-col">
       {files?.map((file, index) => {
@@ -16,7 +21,12 @@ const FileList = ({ files, onDelete, type }: FileListProps) => {
           ...(type !== false ? { fileUrl: file.fileUrl ?? '' } : {}), // fileUrl이 있을 때만 전달
           ...(onDelete ? { onDelete: () => onDelete(file, index) } : {}), // onDelete가 있을 때만 전달
         };
-        return <FileDetail key={file.homeworkFileId} {...fileDetailProps} />;
+        return (
+          <FileDetail
+            key={(file as HomeworkFile).homeworkFileId || (file as LectureFile).lectureFileId}
+            {...fileDetailProps}
+          />
+        );
       })}
     </div>
   );

--- a/src/models/materials.model.ts
+++ b/src/models/materials.model.ts
@@ -8,7 +8,7 @@ export interface SimpleLectureFileBox {
 export interface LectureFileBox {
   lectureFileBoxName: string;
   lectureFileBoxId: number;
-  updateAt: string;
+  updatedAt: string;
 }
 
 // 상세 조회에서 반환되는 데이터

--- a/src/pages/Material/CreateMaterials.tsx
+++ b/src/pages/Material/CreateMaterials.tsx
@@ -1,10 +1,12 @@
-import { ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import { useNavigate, useParams } from 'react-router-dom';
 import { uploadLectureFile } from '../../api/materials.api';
 import LongButton from '../../components/Common/LongButton';
 import AddFile from '../../components/Material/AddFile';
 import Input from '../../components/RoomDetail/Input';
+import Container from '../../components/Common/Container';
+import CreateDesc from '../../components/RoomDetail/CreateDesc';
 
 const CreateMaterials = () => {
   const { roomId } = useParams<{ roomId: string }>();
@@ -33,28 +35,15 @@ const CreateMaterials = () => {
       lectureFiles: fileList,
     };
 
-    // api 호출
-    try {
-      const response = await uploadLectureFile(roomId!, payload);
-      if (response.status == 201) {
-        nav(-1);
-      }
-    } catch (error) {
-      console.log('강의 자료 업로드 실패', error);
-    }
+    // 숙제 업로드
+    await uploadLectureFile(roomId!, payload);
+    nav(-1);
   };
 
   return (
-    <div className="px-4 flex flex-col h-full">
+    <Container>
       {/* 설명 */}
-      <div className="py-4">
-        <p className="text-heading6 font-bold leading-10 text-gray-900">
-          업로드 할 자료의 정보를 입력하세요.
-        </p>
-        <p className="text-body3 font-normal leading-7 tracking-[-0.048px] text-gray-600">
-          언제든지 수정할 수 있어요!
-        </p>
-      </div>
+      <CreateDesc title="업로드 할 자료의 정보를 입력하세요." desc="언제든지 수정할 수 있어요!" />
       {/* 파일첨부 */}
       <div className="py-4 gap-6 flex flex-col">
         <Input
@@ -66,7 +55,6 @@ const CreateMaterials = () => {
         />
         <AddFile fileList={fileList} setFileList={setFileList} />
       </div>
-
       <div className="py-6 mt-auto">
         <LongButton
           enable={!!(fileList.length > 0 && desc.length > 0)}
@@ -74,7 +62,7 @@ const CreateMaterials = () => {
           text="업로드 하기"
         />
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Material/EditMaterial.tsx
+++ b/src/pages/Material/EditMaterial.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { getLectureFileDeatil, patchLectureFile } from '../../api/materials.api';
 import { LectureFile } from '../../models/materials.model';
 import Input from '../../components/RoomDetail/Input';
-import AddFile from '../../components/Material/AddFile';
 import LongButton from '../../components/Common/LongButton';
 import Loading from '../Common/Loading';
-import FileDetail from '../../components/Material/FileDetail';
+import Container from '../../components/Common/Container';
+import FileList from '../../components/Material/FileList';
 
 const EditMaterial = () => {
   const { roomId, materialId } = useParams<{ roomId: string; materialId: string }>();
@@ -21,19 +21,13 @@ const EditMaterial = () => {
     getMaterialDetail();
   }, [roomId, materialId]);
 
+  // 수정을 위한 상세 조회
   const getMaterialDetail = async () => {
     setLoading(true);
-    try {
-      const response = await getLectureFileDeatil(roomId!, materialId!);
-      if (response.status == 200) {
-        setFileList(response.data.lectureFiles);
-        setDesc(response.data.lectureFileBoxName);
-      }
-    } catch (error) {
-      console.log('강의 자료 페이지를 불러오는데 실패했습니다.', error);
-    } finally {
-      setLoading(false);
-    }
+    const response = await getLectureFileDeatil(roomId!, materialId!);
+    setFileList(response.data.lectureFiles);
+    setDesc(response.data.lectureFileBoxName);
+    setLoading(false);
   };
 
   // 기존 파일 삭제
@@ -51,13 +45,8 @@ const EditMaterial = () => {
       removeLectureFiles: removeList,
     };
 
-    try {
-      const data = await patchLectureFile(roomId!, materialId!, payload);
-      console.log('숙제 업로드 성공:', data);
-      nav(-1);
-    } catch (error) {
-      console.error(error);
-    }
+    await patchLectureFile(roomId!, materialId!, payload);
+    nav(-1);
   };
 
   if (loading) {
@@ -65,33 +54,24 @@ const EditMaterial = () => {
   }
 
   return (
-    <div className="px-4 flex flex-col h-full pt-4 gap-6">
-      <Input
-        setDesc={setDesc}
-        desc={desc}
-        name="자료명"
-        placeholder="자료명을 입력해주세요"
-        isAble={true}
-      />
-      <div>
+    <Container>
+      <div className="flex flex-col gap-6 py-4">
+        <Input
+          setDesc={setDesc}
+          desc={desc}
+          name="자료명"
+          placeholder="자료명을 입력해주세요"
+          isAble={true}
+        />
         {fileList.length > 0 && (
-          <div className="text-center text-gray-700 gap-2 flex flex-col">
-            {fileList.map((file, index) => (
-              <FileDetail
-                key={file.lectureFileId}
-                title={file.originalName}
-                onDelete={() => handleFileDelete(file, index)}
-              />
-            ))}
-          </div>
+          <FileList files={fileList} onDelete={handleFileDelete} type={false} />
         )}
       </div>
-      <AddFile setFileList={setAddList} fileList={addList} />
       {/* 버튼 */}
       <div className="py-6 mt-auto">
-        <LongButton enable={!!(desc.length > 0)} onClick={handleSubmit} text="수정 완료" />
+        <LongButton enable={!!(desc.length > 0)} onClick={handleSubmit} text="수정 완료" />{' '}
       </div>
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Material/MaterialDetail.tsx
+++ b/src/pages/Material/MaterialDetail.tsx
@@ -1,4 +1,4 @@
-import { useDebugValue, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getLectureFileDeatil } from '../../api/materials.api';
 import { LectureFileBoxDetail } from '../../models/materials.model';
@@ -8,6 +8,9 @@ import Modal from '../../components/Modal/Modal';
 import RoomDeleteModal from '../../components/Modal/RoomDeleteModal';
 import useDeleteStore from '../../store/useDeleteStore';
 import FileDetail from '../../components/Material/FileDetail';
+import Container from '../../components/Common/Container';
+import Description from '../../components/RoomDetail/Description';
+import FileList from '../../components/Material/FileList';
 
 const MaterialDetail = () => {
   const nav = useNavigate();
@@ -21,18 +24,12 @@ const MaterialDetail = () => {
     getMaterialDetail();
   }, [roomId, materialId]);
 
+  // 강의 자료 상세 조회
   const getMaterialDetail = async () => {
     setLoading(true);
-    try {
-      const response = await getLectureFileDeatil(roomId!, materialId!);
-      if (response.status == 200) {
-        setLectureFiles(response.data);
-      }
-    } catch (error) {
-      console.log('강의 자료 페이지를 불러오는데 실패했습니다.', error);
-    } finally {
-      setLoading(false);
-    }
+    const response = await getLectureFileDeatil(roomId!, materialId!);
+    setLectureFiles(response.data);
+    setLoading(false);
   };
 
   if (loading) {
@@ -44,29 +41,18 @@ const MaterialDetail = () => {
   }
 
   return (
-    <div className="flex flex-col">
-      <div className="py-4 px-4">
-        <div className="flex items-center justify-between">
-          <p className="text-heading6 font-bold leading-10 text-gray-900">{lectureFiles.lectureFileBoxName}</p>
-          {userRole == 'TEACHER' ? <Edit onClick={() => nav(`edit`)} /> : ''}
-        </div>
-        <p className="text-body4 font-normal leading-7 tracking-[-0.048px] text-gray-600">
-          업로드 날짜 {lectureFiles.updatedAt}
-        </p>
-      </div>
-      <div className="mx-4 flex flex-col gap-2">
-        {lectureFiles.lectureFiles.map((file) => (
-          <div>
-            <FileDetail title={file.originalName} fileUrl={file.fileUrl} key={file.lectureFileId} />
-          </div>
-        ))}
-      </div>
+    <Container>
+      <Description
+        title={lectureFiles.lectureFileBoxName}
+        desc={`업로드 날짜 ${lectureFiles.updatedAt}`}
+      />
+      <FileList files={lectureFiles.lectureFiles} />
       {modalOpen && (
         <Modal onClose={() => setModalOpen(false)}>
           <RoomDeleteModal setModalOpen={setModalOpen} what={what} />
         </Modal>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/src/pages/Material/Materials.tsx
+++ b/src/pages/Material/Materials.tsx
@@ -6,10 +6,12 @@ import Preview_1 from '../../components/Material/Preview_1';
 import Button from '../../components/RoomDetail/Button';
 import { getLectureFileBoxes } from '../../api/materials.api';
 import Toast from '../../components/Modal/Toast';
+import Container from '../../components/Common/Container';
+import { searchFilter } from '../../utils/SearchFilter';
 
 const Materials = () => {
   const nav = useNavigate();
-  const { roomId } = useParams<{ roomId: string }>();
+  const { roomId } = useParams<{ roomId?: string }>();
   const [materialList, setMaterialList] = useState<LectureFileBox[]>([]);
   const [search, setSearch] = useState('');
   const userRole = localStorage.getItem('roleInfo');
@@ -17,38 +19,32 @@ const Materials = () => {
   const location = useLocation();
   const [toast, setToast] = useState(location.state?.toast || false);
 
+  // 강의 자료 목록 조회
   useEffect(() => {
     const getMaterials = async () => {
-      try {
-        const response = await getLectureFileBoxes(roomId!);
-        if (response.status == 200) {
-          setMaterialList(response.data.lectureFileBoxes);
-        }
-      } catch (error) {
-        console.log('강의 자료 목록 조회 실패', error);
-      }
+      const response = await getLectureFileBoxes(roomId!);
+      setMaterialList(response.data.lectureFileBoxes);
     };
 
     getMaterials();
   }, []);
 
-  const filteredMaterials = materialList.filter((material) => {
-    if (search && search.length === 10 && search.includes('.')) {
-      return material.updateAt.includes(search);
-    }
-
-    return material.lectureFileBoxName.toLowerCase().includes(search.toLowerCase());
+  // 검색 필터 적용
+  const filteredMaterials = searchFilter(materialList, {
+    search,
+    filterByDate: true,
+    filterByTitle: true,
   });
 
   return (
-    <div className="flex flex-col px-4 h-full relative">
+    <Container>
       <div className="py-4">
         <SearchBar value={search} setValue={setSearch} />
       </div>
       {filteredMaterials.map((material) => (
         <Preview_1
           title={material.lectureFileBoxName}
-          updatedAt={material.updateAt}
+          updatedAt={material.updatedAt}
           type="materials"
           id={material.lectureFileBoxId}
           key={material.lectureFileBoxId}
@@ -57,7 +53,7 @@ const Materials = () => {
       {userRole == 'TEACHER' ? <Button text="자료 업로드하기" onClick={() => nav('create')} /> : ''}
       <Outlet />
       {toast && <Toast setToast={setToast} title="강의 자료 삭제가 완료되었습니다." />}
-    </div>
+    </Container>
   );
 };
 

--- a/src/utils/DownloadFiles.ts
+++ b/src/utils/DownloadFiles.ts
@@ -1,17 +1,13 @@
 // 파일 다운로드 유틸리티 함수
 export const downloadFile = async (fileUrl: string) => {
-  try {
-    const res = await fetch(fileUrl);
-    const blob = await res.blob();
+  const res = await fetch(fileUrl);
+  const blob = await res.blob();
 
-    const link = document.createElement('a');
-    const url = window.URL.createObjectURL(blob);
-    link.href = url;
-    link.download = fileUrl.split('/').pop() || 'file';
-    link.click();
+  const link = document.createElement('a');
+  const url = window.URL.createObjectURL(blob);
+  link.href = url;
+  link.download = fileUrl.split('/').pop() || 'file';
+  link.click();
 
-    window.URL.revokeObjectURL(url);
-  } catch (error) {
-    console.error('파일 다운로드 실패', error);
-  }
+  window.URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## 🔥 Issues
#113 

## ✅ What to do

- [x] 공통 컴포넌트 분리
- [x] api코드에서 try-catch문 사용하도록 수정

## 📄 Description

상세 설명

## 🤔 Considerations
* HomeworkFile과 LectureFile 모두에서 FileList를 사용해야 했음.
  * 제네릭을 사용해 유니온 타입을 제거하고, 두 타입에서 모두 활용할 수 있도록 수정.
  * 각 타입의 id를 안전하게 처리하도록 key 값을 동적으로 설정.

## 🛠️ Improvements to Make

개선할 사항

## 👀 References
https://hyunseob.github.io/2017/01/14/typescript-generic/
