### PR TITLE
[Feat] interceptor에서 API 에러 핸들링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-copy-to-clipboard": "^5.1.0",
         "react-datepicker": "^7.6.0",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.1",
         "recharts": "^2.15.1",
@@ -5782,6 +5783,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7405,6 +7414,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-datepicker": "^7.6.0",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.1",
     "recharts": "^2.15.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,32 @@
 import './App.css';
 import { router } from './routes/Router';
 import { RouterProvider } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
+import { useEffect, useState } from 'react';
+import ErrorPage from './components/Fallback/ErrorPage';
 
 function App() {
-  return <RouterProvider router={router} />;
+  const [errorInfo, setErrorInfo] = useState<{ status: number; message: string } | null>(null);
+
+  useEffect(() => {
+    const handleErrorEvent = (e: any) => {
+      setErrorInfo(e.detail);
+    };
+
+    window.addEventListener('triggerErrorUI', handleErrorEvent);
+    return () => window.removeEventListener('triggerErrorUI', handleErrorEvent);
+  }, []);
+
+  if (errorInfo) {
+    return <ErrorPage status={errorInfo.status} message={errorInfo.message} />;
+  }
+
+  return (
+    <>
+      <Toaster />
+      <RouterProvider router={router} />
+    </>
+  );
 }
 
 export default App;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import toast from 'react-hot-toast';
 
 const baseURL = import.meta.env.VITE_BASE_URL;
 
@@ -27,14 +28,14 @@ instance.interceptors.request.use(
 );
 
 instance.interceptors.response.use(
-  (response) => {
-    return response;
-  },
+  (response) => response,
   async (error) => {
+    const status = error.response.status;
+    const method = error.config.method.toUpperCase();
     const refreshToken = localStorage.getItem('refreshToken');
 
-    // 메세지에 상관없이 코드가 401이면 모두 토큰 재발급
-    if (error.response.status === 401) {
+    // 기존 토큰 재발급 코드
+    if (status === 401 && refreshToken) {
       try {
         const res = await axios.post(
           `${baseURL}/api/auth/kakao/reissue`,
@@ -47,29 +48,48 @@ instance.interceptors.response.use(
           },
         );
 
-        if (res.status == 200) {
+        if (res.status === 200) {
           const { accessToken, refreshToken } = res.data.data;
           localStorage.setItem('accessToken', accessToken);
           localStorage.setItem('refreshToken', refreshToken);
 
           const decoded = jwtDecode(accessToken) as JwtPayload & { role: string };
           localStorage.setItem('roleInfo', decoded.role);
-          console.log('재발급 완료');
+          console.log('🔁 토큰 재발급 성공');
+
+          // 요청 재시도
+          error.config.headers.Authorization = `Bearer ${accessToken}`;
+          return axios(error.config);
         }
-
-        // 새 토큰으로 헤더 업데이트 후 재요청
-        error.config.headers.Authorization = `Bearer ${res.data.data.accessToken}`;
-        return axios(error.config);
       } catch (refreshErr) {
-        console.log('Token 갱신 실패: ', refreshErr);
-
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        localStorage.removeItem('roleInfo');
-
+        console.log('🚫 토큰 재발급 실패:', refreshErr);
+        localStorage.clear();
         window.location.href = '/login';
+        return Promise.reject(refreshErr);
       }
     }
+
+    // 에러 처리 코드
+    const statusMessages: Record<number, string> = {
+      400: '잘못된 요청입니다.',
+      403: '접근 권한이 없습니다.',
+      404: '요청하신 데이터를 찾을 수 없습니다.',
+      413: '파일의 용량이 너무 큽니다.',
+      500: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    };
+
+    const message = statusMessages[status] || '알 수 없는 오류가 발생했습니다.';
+
+    if (method === 'GET') {
+      window.dispatchEvent(
+        new CustomEvent('triggerErrorUI', {
+          detail: { status, message },
+        }),
+      );
+    } else {
+      toast.error(message);
+    }
+
     return Promise.reject(error);
   },
 );

--- a/src/components/Fallback/ErrorPage.tsx
+++ b/src/components/Fallback/ErrorPage.tsx
@@ -1,0 +1,21 @@
+interface ErrorPageProps {
+  status: number;
+  message: string;
+}
+
+const ErrorPage = ({ status, message }: ErrorPageProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen text-center">
+      <h1 className="text-4xl font-bold mb-4">Error {status}</h1>
+      <p className="text-lg mb-6">{message}</p>
+      <button
+        onClick={() => window.location.reload()}
+        className="bg-black text-white px-4 py-2 rounded"
+      >
+        새로고침
+      </button>
+    </div>
+  );
+};
+
+export default ErrorPage;


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] interceptor에서 에러 핸들링

## 📄 Description
* Axios 인터셉터의 `response`에서 에러 상황을 통합적으로 관리하도록 설정
* 401 에러는 토큰 재발급 로직 처리
* GET 요청 실패 시, UI에 에러 전달
* POST 요청 실패 시, 토스트로 에러 메시지 노출

## 🤔 Considerations
- 원래는 `react-error-boundary`를 사용하여 에러를 처리하려 했으나, `react-query`를 사용하지 않아 비동기 요청에서 발생하는 에러를 자동으로 잡을 수 없었음
- 그래서 `try-catch`로 감싸고 공통 컴포넌트를 만들어 예외 처리를 넘기려 했지만, 
  - `toast`는 바로 띄울 수 있어 괜찮았지만
  - `ErrorPage`처럼 전체 에러 UI를 보여주려면 상태를 올려 `setError()`로 전달해야 했고,
  - 이는 다음 렌더링 주기에서 처리되어 즉각적인 에러 반영이 어려웠음
- 결국 `interceptor`에서 에러를 잡고, `GET` 요청은 전체 에러 페이지를 보여주고, `POST` 요청은 `toast`만 띄우는 방향으로 처리
- `window.dispatchEvent`로 전역 에러 상태를 발생시켜 상위 컴포넌트에서 `ErrorPage` 렌더링이 가능하도록 구현
- 단, 이 방식은 명시적인 props 전달이 없고 전역 이벤트에 의존하므로 직관성이 떨어질 수 있음



## 🛠️ Improvements to Make
- 인터셉터 외의 비동기 함수에서 발생하는 에러 처리 구조 정리
-`window.dispatchEvent`보다 상태 기반 전역 에러 핸들링 구조로 변경할 수 있을지 검토
- 사용자에게 더 명확하고 친절한 에러 메시지 문구 정의 필요

## 👀 References

스크린샷 또는 참고사항
