### PR TITLE
[Fix] 파일 컴포넌트 UI 수정

### DIFF
--- a/src/components/Material/FileDetail.tsx
+++ b/src/components/Material/FileDetail.tsx
@@ -16,11 +16,11 @@ const FileDetail = ({ title, fileUrl, onDelete }: FileDetailProps) => {
       <div className="p-1">
         <FaRegFileAlt size={24} fill="#242421" />
       </div>
-      <div className="flex gap-4 items-center flex-1">
+      <div className="flex gap-4 items-center flex-1 overflow-hidden">
         <img src={vector_gray} className="w-[3px] h-[24px]" />
-        <div className="tracking-[-0.048px] flex flex-col items-start">
-          <p className="text-body3 font-semibold leading-7 text-gray-900">{title}</p>
-        </div>
+        <p className="truncate tracking-[-0.048px] text-body3 font-semibold leading-7 text-gray-900">
+          {title}
+        </p>
       </div>
       <div>
         {fileUrl ? (

--- a/src/components/Material/FileDetail.tsx
+++ b/src/components/Material/FileDetail.tsx
@@ -12,7 +12,7 @@ interface FileDetailProps {
 
 const FileDetail = ({ title, fileUrl, onDelete }: FileDetailProps) => {
   return (
-    <div className="p-4 flex gap-3 items-center bg-gray-100 rounded-lg">
+    <div className="p-5 flex gap-3 items-center bg-gray-100 rounded-lg">
       <div className="p-1">
         <FaRegFileAlt size={24} fill="#242421" />
       </div>
@@ -20,7 +20,6 @@ const FileDetail = ({ title, fileUrl, onDelete }: FileDetailProps) => {
         <img src={vector_gray} className="w-[3px] h-[24px]" />
         <div className="tracking-[-0.048px] flex flex-col items-start">
           <p className="text-body3 font-semibold leading-7 text-gray-900">{title}</p>
-          <p className="text-body4 font-normal leading-[25px] text-gray-500">7.5B</p>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 파일 컴포넌트에서 파일 크기 삭제
- [x] 파일명 overflow issue 해결

## 📄 Description
* 기존 파일 컴포넌트에서 사용자에게 불필요하다는 의견이 있었던 파일 크기 표시를 제거
* 파일명이 길 경우 박스를 넘던 문제를 `truncate`를 적용해 말줄임표로 처리하여 UI가 깨지지 않도록 수정

## 🤔 Considerations
* 이전에는 박스 없이 텍스트만 보여주어서, 글자가 너무 길 경우 문자 수를 제한하고 직접 잘라 `...`을 붙이는 방식을 사용했다.
* 이번에는 텍스트를 감싸는 박스가 있어서 `overflow` 속성을 활용할 수 있겠다고 생각했고, 찾아보니 Tailwind의 `truncate` 클래스를 사용하면 자동으로 말줄임표 처리가 가능하다는 것을 알게 되어 이를 적용했다.

## 🛠️ Improvements to Make

개선할 사항

## 👀 References
<img width="346" alt="Screenshot 2025-05-01 at 10 09 35 AM" src="https://github.com/user-attachments/assets/e36d3c3a-d9ed-4d24-8428-afd4b8d0cc15" />
<img width="348" alt="Screenshot 2025-05-01 at 10 09 24 AM" src="https://github.com/user-attachments/assets/4f366032-cb11-4ef6-a968-4cf3bd6ec6a6" />

