### PR TITLE
[Fix] 에러 처리 수정 및 마이페이지 한줄소개 수정

### DIFF
--- a/src/components/Modal/CreateModal.tsx
+++ b/src/components/Modal/CreateModal.tsx
@@ -8,6 +8,7 @@ interface ModalProps {
   setModalOpen: (value: boolean) => void;
   type: string;
   id?: number;
+  message?: string;
 }
 
 export interface GradeType {
@@ -15,7 +16,7 @@ export interface GradeType {
   grade: number;
 }
 
-const CreateModal = ({ setModalOpen, type, id }: ModalProps) => {
+const CreateModal = ({ setModalOpen, type, id, message }: ModalProps) => {
   const [name, setName] = useState('');
   const [grade, setGrade] = useState('');
   const [test, setTest] = useState('');
@@ -82,7 +83,7 @@ const CreateModal = ({ setModalOpen, type, id }: ModalProps) => {
           </>
         ) : (
           <Input
-            placeholder="상태메세지를 입력해주세요"
+            placeholder={message || '상태메세지를 입력해주세요'}
             name=""
             desc={msg}
             setDesc={setMsg}

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -46,7 +46,11 @@ const MyPage = () => {
       )}
       {messageOpen && (
         <Modal onClose={() => setMessageOpen(false)}>
-          <CreateModal setModalOpen={setMessageOpen} type={'상태메세지'} />
+          <CreateModal
+            setModalOpen={setMessageOpen}
+            type={'상태메세지'}
+            message={userInfo.statusMessage}
+          />
         </Modal>
       )}
     </div>

--- a/src/utils/getAPIResponseData.ts
+++ b/src/utils/getAPIResponseData.ts
@@ -12,25 +12,6 @@ const getAPIResponseData = async <T, D = T>(option: AxiosRequestConfig<D>): Prom
 
     return data as T;
   } catch (e) {
-    if (e instanceof AxiosError) {
-      const method = option.method?.toUpperCase();
-
-      // 공통
-      if (e.response?.status === 500) {
-        localStorage.clear();
-        window.location.href = '/';
-        return Promise.reject(e);
-      }
-
-      // POST - 토스트 띄우기
-      if (method === 'POST') {
-      }
-
-      // GET - 에러 페이지 띄우기
-      if (method === 'GET') {
-      }
-    }
-
     throw e;
   }
 };


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 에러 500일 때 로그아웃되는 문제 해결
- [x] 마이페이지 상태메세지 변경 시 기존 내용을 Placeholder로 표시

## 📄 Description
* 에러 500일 때 로그아웃되는 문제를 해결
* 마이페이지에서 상태 메세지 변경 시 기존 상태 메세지를 placeholder로 표시되게 수정했다.

## 🤔 Considerations
* 500 에러가 발생했을 때, axios 인터셉터에서 정의한 에러 처리 로직이 실행되지 않고 곧바로 로그아웃되는 문제
* 확인 결과, `getResponseData.ts`에서 500 에러 시 `localStorage.clear()`와 함께 바로 `return Promise.reject(e);`를 하고 있었던 것이 원인이었다.
* 에러 처리 로직은 이미 인터셉터에서 공통으로 처리하고 있기 때문에, 해당 위치에서는 단순히 `throw e`만 해주는 것이 더 적절하다고 판단해 그렇게 수정.

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
