### PR TITLE
[Feat] 채팅 목록 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.9",
         "clipboard-copy": "^4.0.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.9.4",
         "jwt-decode": "^4.0.0",
         "postcss": "^8.4.49",
         "react": "^18.3.1",
@@ -5575,6 +5576,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.9.4.tgz",
+      "integrity": "sha512-yaeGDmGQ3eCQEwZ95/pRQMaSh/Q4E2CK6JYOclG/PdjyQad0MULJ+JFVV8911Fl5a6tF6o0wgW8Dpl5Qx4Adjg==",
+      "dependencies": {
+        "motion-dom": "^12.9.4",
+        "motion-utils": "^12.9.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6681,6 +6708,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.9.4.tgz",
+      "integrity": "sha512-25TWkQPj5I18m+qVjXGtCsxboY11DaRC5HMjd29tHKExazW4Zf4XtAagBdLpyKsVuAxEQ6cx5/E4AB21PFpLnQ==",
+      "dependencies": {
+        "motion-utils": "^12.9.4"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.9.4.tgz",
+      "integrity": "sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8486,8 +8526,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/turbo-stream": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.7.9",
     "clipboard-copy": "^4.0.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.9.4",
     "jwt-decode": "^4.0.0",
     "postcss": "^8.4.49",
     "react": "^18.3.1",

--- a/src/assets/images/Chatting/Meatballs_Horizental menu.svg
+++ b/src/assets/images/Chatting/Meatballs_Horizental menu.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Meatballs_Horizental menu">
+<circle id="Ellipse 206" cx="12" cy="12" r="1" transform="rotate(-90 12 12)" stroke="#C6C4C1" stroke-width="2" stroke-linecap="round"/>
+<circle id="Ellipse 207" cx="12" cy="18" r="1" transform="rotate(-90 12 18)" stroke="#C6C4C1" stroke-width="2" stroke-linecap="round"/>
+<circle id="Ellipse 208" cx="12" cy="6" r="1" transform="rotate(-90 12 6)" stroke="#C6C4C1" stroke-width="2" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/components/Chatting/ChatPreview.tsx
+++ b/src/components/Chatting/ChatPreview.tsx
@@ -1,7 +1,10 @@
 import student_boy from '../../assets/images/student_boy.png';
 import Menu from '../../assets/images/Chatting/Meatballs_Horizental menu.svg?react';
+import { useState } from 'react';
 
 const ChatPreview = () => {
+  const [showMenu, setShowMenu] = useState(false);
+
   return (
     <div className="px-4 flex gap-4 items-center py-3">
       {/* 프로필 사진 */}
@@ -22,7 +25,13 @@ const ChatPreview = () => {
           <p>선생님</p>
         </div>
       </div>
-      <Menu />
+      <Menu onClick={() => setShowMenu(!showMenu)} />
+      {showMenu && (
+        <div className="absolute right-6 mt-24 border-[1px] border-gray-500 rounded-xl text-body4 text-gray-500">
+          <div className="flex border-b-[1px] px-2 py-1 items-center">채팅방 나가기</div>
+          <div className="flex px-2 py-1 justify-center">알림끄기</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Chatting/ChatPreview.tsx
+++ b/src/components/Chatting/ChatPreview.tsx
@@ -1,37 +1,54 @@
-import student_boy from '../../assets/images/student_boy.png';
-import Menu from '../../assets/images/Chatting/Meatballs_Horizental menu.svg?react';
+import { motion, useAnimation } from 'framer-motion';
 import { useState } from 'react';
+import student_boy from '../../assets/images/student_boy.png';
+import { MdLogout } from 'react-icons/md';
+import { MdOutlineAlarmOff } from 'react-icons/md';
 
 const ChatPreview = () => {
-  const [showMenu, setShowMenu] = useState(false);
+  const [showActions, setShowActions] = useState(false);
+  const controls = useAnimation();
+
+  const handleDragEnd = (event: any, info: any) => {
+    if (info.offset.x < -100) {
+      setShowActions(true);
+    } else {
+      controls.start({ x: 0 });
+      setShowActions(false);
+    }
+  };
 
   return (
-    <div className="px-4 flex gap-4 items-center py-3">
-      {/* 프로필 사진 */}
-      <div
-        className="flex w-[60px] h-[60px] p-3 rounded-2xl cursor-pointer items-center justify-center"
-        style={{ backgroundColor: '#E1F5D6' }}
-      >
-        <img className="h-9 max-w-9" src={student_boy} />
-      </div>
-      {/* 정보 */}
-      <div className="flex-1 flex flex-col">
-        <h1 className="text-base font-semibold leading-7">국어</h1>
-        <h3 className="font-medium text-gray-500 leading-[26px] text-body4">
-          선생님, 숙제 다 못했어요
-        </h3>
-        <div className="font-normal text-gray-500 leading-[25px] text-body4 flex gap-1">
-          <p className="text-gray-950">홍길동</p>
-          <p>선생님</p>
-        </div>
-      </div>
-      <Menu onClick={() => setShowMenu(!showMenu)} />
-      {showMenu && (
-        <div className="absolute right-6 mt-24 border-[1px] border-gray-500 rounded-xl text-body4 text-gray-500">
-          <div className="flex border-b-[1px] px-2 py-1 items-center">채팅방 나가기</div>
-          <div className="flex px-2 py-1 justify-center">알림끄기</div>
+    <div className="relative overflow-hidden">
+      {showActions && (
+        <div className="absolute inset-0 bg-gray-100 flex items-center z-0 justify-end">
+          <div className="bg-blue-400 h-full w-[80px] justify-center flex items-center">
+            <MdOutlineAlarmOff size={28} fill="#ffffff" />
+          </div>
+          <div className="bg-red-400 h-full w-[80px] justify-center flex items-center">
+            <MdLogout size={28} fill="#ffffff" />
+          </div>
         </div>
       )}
+      <motion.div
+        drag="x"
+        dragConstraints={{ left: -160, right: 0 }}
+        onDragEnd={handleDragEnd}
+        animate={controls}
+        className="bg-white px-4 py-3 flex gap-4 items-center z-10 relative"
+      >
+        <div
+          className="flex w-[60px] h-[60px] p-3 rounded-2xl cursor-pointer items-center justify-center"
+          style={{ backgroundColor: '#E1F5D6' }}
+        >
+          <img className="h-9 max-w-9" src={student_boy} />
+        </div>
+        <div className="flex-1 flex flex-col">
+          <h1 className="text-base font-semibold leading-7">홍길동 선생님</h1>
+          <h3 className="font-medium text-gray-500 leading-[26px] text-body4">
+            선생님, 숙제 다 못했어요
+          </h3>
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/src/components/Chatting/ChatPreview.tsx
+++ b/src/components/Chatting/ChatPreview.tsx
@@ -1,0 +1,30 @@
+import student_boy from '../../assets/images/student_boy.png';
+import Menu from '../../assets/images/Chatting/Meatballs_Horizental menu.svg?react';
+
+const ChatPreview = () => {
+  return (
+    <div className="px-4 flex gap-4 items-center py-3">
+      {/* 프로필 사진 */}
+      <div
+        className="flex w-[60px] h-[60px] p-3 rounded-2xl cursor-pointer items-center justify-center"
+        style={{ backgroundColor: '#E1F5D6' }}
+      >
+        <img className="h-9 max-w-9" src={student_boy} />
+      </div>
+      {/* 정보 */}
+      <div className="flex-1 flex flex-col">
+        <h1 className="text-base font-semibold leading-7">국어</h1>
+        <h3 className="font-medium text-gray-500 leading-[26px] text-body4">
+          선생님, 숙제 다 못했어요
+        </h3>
+        <div className="font-normal text-gray-500 leading-[25px] text-body4 flex gap-1">
+          <p className="text-gray-950">홍길동</p>
+          <p>선생님</p>
+        </div>
+      </div>
+      <Menu />
+    </div>
+  );
+};
+
+export default ChatPreview;

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -2,8 +2,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { GoArrowLeft } from 'react-icons/go';
 import { useEffect, useMemo, useState } from 'react';
 import { FiTrash2 } from 'react-icons/fi';
-import Modal from '../Modal/Modal';
-import RoomDeleteModal from '../Modal/RoomDeleteModal';
 import useDeleteStore from '../../store/useDeleteStore';
 
 // 뒤로 가기 없는 페이지들
@@ -11,6 +9,7 @@ const ROUTE_TITLES: { [key: string]: string } = {
   '/user/mypage': '내 정보',
   '/user/calendar': '달력',
   '/user/roomlist': '과외방',
+  '/user/chatList': '채팅 목록',
 };
 
 // 뒤로 가기 존재

--- a/src/components/Common/NavBar.tsx
+++ b/src/components/Common/NavBar.tsx
@@ -8,6 +8,7 @@ import HomeFill from '../../assets/images/homeFill.svg?react';
 import MypageSvg from '../../assets/images/mypage.svg?react';
 import MyPageFill from '../../assets/images/mypageFill.svg?react';
 import Indicator from '../../assets/images/Indicator.svg?react';
+import { IoChatbubblesSharp } from 'react-icons/io5';
 
 const NavBar = () => {
   const nav = useNavigate();
@@ -16,7 +17,7 @@ const NavBar = () => {
 
   useEffect(() => {
     const pathname = location.pathname.split('/');
-    if (pathname[2] === 'calendar' || pathname[2] === 'mypage') {
+    if (pathname[2] === 'calendar' || pathname[2] === 'mypage' || pathname[2] === 'chatList') {
       setCurrentMenu(pathname[2]);
     } else {
       setCurrentMenu('roomlist');
@@ -37,6 +38,12 @@ const NavBar = () => {
       active: <CalendarFill className="w-6 h-6" />,
     },
     {
+      menu: '채팅',
+      name: 'chatList',
+      inactive: <IoChatbubblesSharp className="w-5 h-5 mt-[2px] mb-[2px]" fill="#8D8D8A" />,
+      active: <IoChatbubblesSharp className="w-5 h-5 mt-[2px] mb-[2px]" fill="#12B500" />,
+    },
+    {
       menu: '내 정보',
       name: 'mypage',
       inactive: <MypageSvg className="w-6 h-6" />,
@@ -46,7 +53,7 @@ const NavBar = () => {
 
   return (
     <div className="border-t border-gray-200 flex bg-white">
-      <div className="grid grid-cols-3 w-full px-[7.5px]">
+      <div className="grid grid-cols-4 w-full px-[7.5px]">
         {menus.map((menuItem) => (
           <div
             key={menuItem.name}

--- a/src/pages/Chatting/ChatList.tsx
+++ b/src/pages/Chatting/ChatList.tsx
@@ -1,5 +1,21 @@
+import { useState } from 'react';
+import Search from '../../components/Room/Search';
+import ChatPreview from '../../components/Chatting/ChatPreview';
+
 const ChatList = () => {
-  return <div>채팅 목록</div>;
+  const [search, setSearch] = useState('');
+  const onChangeSearch = () => {};
+
+  return (
+    <div className="flex flex-col">
+      <Search value={search} onChangeSearch={onChangeSearch} />
+      <div>
+        <ChatPreview />
+        <ChatPreview />
+        <ChatPreview />
+      </div>
+    </div>
+  );
 };
 
 export default ChatList;

--- a/src/pages/Chatting/ChatList.tsx
+++ b/src/pages/Chatting/ChatList.tsx
@@ -1,0 +1,5 @@
+const ChatList = () => {
+  return <div>채팅 목록</div>;
+};
+
+export default ChatList;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -34,6 +34,7 @@ import RoomDetail from '../pages/RoomDetail/RoomDetail';
 import Calendar from '../pages/Calendar/Calendar';
 import MyPage from '../pages/MyPage/MyPage';
 import UserPolicy from '../pages/MyPage/UserPolicy';
+import ChatList from '../pages/Chatting/ChatList';
 
 export const router = createBrowserRouter([
   {
@@ -92,6 +93,7 @@ export const router = createBrowserRouter([
       { path: 'sharecode', element: <ShareCode /> },
       { path: 'calendar', element: <Calendar /> },
       { path: 'mypage', element: <MyPage /> },
+      { path: 'chatList', element: <ChatList /> }, // 채팅 목록
     ],
   },
   {


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 네브바에 채팅 추가
- [x] 채팅방 목록 UI 구현

## 📄 Description
* 채팅 기능이 추가되어, 네브바에 채팅 메뉴 항목을 배치하고 채팅방 목록 UI를 구현하였다.
* 채팅방은 리스트 형태로 보여지며, 각 채팅방은 사용자 정보와 마지막 메시지를 포함한다.
* 각 채팅방 아이템을 좌측으로 드래그하면 알림 끄기, 채팅방 나가기 버튼이 나타난다.

## 🤔 Considerations
* 처음에는 채팅방 우측에 '메뉴' 버튼을 두고, 클릭 시 모달 형태로 "채팅방 나가기", "알림 끄기" 옵션을 보여주려고 했다. 하지만 UI 흐름이 단조롭고 모바일 UX에 적합하지 않다고 판단하여 슬라이드 메뉴 형태로 변경하고자 했다.
* 어떻게 드래그로 슬라이드 인터랙션을 구현할 수 있을지 고민하다가 `framer-motion`의 `drag` 속성과 `useAnimation` 훅을 활용하기로 했다. 드래그 이벤트에서 `info.offset.x` 값을 기준으로 조건을 분기하여, -100보다 작게 이동되면 액션 버튼이 노출되고, 그렇지 않으면 원래 위치로 복원되도록 로직을 작성했다.

## 🛠️ Improvements to Make
* 채팅방 목록에서 실시간 알림 뱃지 처리

## 👀 References
<img width="343" alt="image" src="https://github.com/user-attachments/assets/4013d545-73f6-4f21-8f20-5e845036f257" />
<img width="344" alt="image" src="https://github.com/user-attachments/assets/82536998-beb8-4f87-84cd-7389a0b5ed99" />

